### PR TITLE
Initial model of `Vat` contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,12 @@ $(K_SUBMODULE)/mvn.timestamp: $(K_SUBMODULE)/submodule.timestamp
 MAIN_MODULE       := MKR-MCD
 SYNTAX_MODULE     := $(MAIN_MODULE)
 MAIN_DEFN_FILE    := mkr-mcd
-KOMPILE_OPTS      ?= 
+KOMPILE_OPTS      ?=
 LLVM_KOMPILE_OPTS := $(KOMPILE_OPTS) -ccopt -O2
+
+k_files       = $(MAIN_DEFN_FILE).k mkr-mcd.k mkr-mcd-data.k
+llvm_files    = $(patsubst %,$(DEFN_DIR)/llvm/%,$(k_files))
+haskell_files = $(patsubst %,$(DEFN_DIR)/haskell/%,$(k_files))
 
 llvm_kompiled    := $(DEFN_DIR)/llvm/$(MAIN_DEFN_FILE)-kompiled/interpreter
 haskell_kompiled := $(DEFN_DIR)/haskell/$(MAIN_DEFN_FILE)-kompiled/definition.kore
@@ -80,10 +84,6 @@ build-llvm:    $(llvm_kompiled)
 build-haskell: $(haskell_kompiled)
 
 # Generate definitions from source files
-
-k_files=$(MAIN_DEFN_FILE).k
-llvm_files    = $(patsubst %,$(DEFN_DIR)/llvm/%,$(k_files))
-haskell_files = $(patsubst %,$(DEFN_DIR)/haskell/%,$(k_files))
 
 defn: llvm-defn
 defn-llvm: $(llvm_files)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,47 @@ KMCD - MKR Multi-Collateral Dai (MCD) KSpecification
 
 **UNDER CONSTRUCTION**
 
-Useful links:
+Useful Links
+------------
 
 -   Initial RFP for security audits: <https://www.notion.so/MCD-Security-Audit-ac578a595ac74958877106c77f1b85b0>
 -   K-DSS bytecode verification: <https://dapp.ci/k-dss/>
 -   DSS solidity sources: <https://github.com/makerdao/dss>
+-   Useful invariants: <https://hackmd.io/lWCjLs9NSiORaEzaWRJdsQ> (maybe work `take` is out of date)
+
+Potential Properties
+--------------------
+
+-   After executing method X of contract C, the suffix of the log will contain these events ...
+-   Every time a `ward` changes, a log event should be emmitted which says so (and the log event should have the correct data).
+    Will only apply to methods which have `note` modifier, but perhaps should be always.
+-   Fundamental equation of Dai (invariant over CDPs + dai).
+
+Order to Model
+--------------
+
+-   vat.sol
+-   lib.sol
+
+Second layer:
+
+-   jug.sol
+-   pot.sol
+-   spot.sol
+
+Collateral:
+
+-   dai.sol
+-   join.sol
+
+Auctions:
+
+-   vow.sol
+-   cat.sol
+-   flop.sol
+-   flip.sol
+-   flap.sol
+
+Global:
+
+-   end.sol

--- a/mkr-mcd-data.md
+++ b/mkr-mcd-data.md
@@ -1,0 +1,34 @@
+MKR MCD Data
+============
+
+This file defines the primitive data-types used in the MKR MCD system.
+
+```k
+module MKR-MCD-DATA
+    imports INT
+    imports MAP
+```
+
+Base Data
+---------
+
+-   `Wad`: fixed point decimal with 18 decimals (for basic quantities, e.g. balances).
+-   `Ray`: fixed point decimal with 27 decimals (for precise quantites, e.g. ratios).
+-   `Rad`: fixed point decimal with 45 decimals (result of integer multiplication with a `Wad` and a `Ray`).
+
+**TODO**: Should we add operators like `+Wad` which emulate the precision limits described here, or assume the abstract model to be inifinite precision?
+
+```k
+    syntax Wad ::= Int
+ // ------------------
+
+    syntax Ray ::= Int
+ // ------------------
+
+    syntax Rad ::= Int
+ // ------------------
+```
+
+```k
+endmodule
+```

--- a/mkr-mcd-data.md
+++ b/mkr-mcd-data.md
@@ -5,6 +5,7 @@ This file defines the primitive data-types used in the MKR MCD system.
 
 ```k
 module MKR-MCD-DATA
+    imports BOOL
     imports INT
     imports MAP
 ```
@@ -12,11 +13,12 @@ module MKR-MCD-DATA
 Base Data
 ---------
 
--   `Wad`: fixed point decimal with 18 decimals (for basic quantities, e.g. balances).
--   `Ray`: fixed point decimal with 27 decimals (for precise quantites, e.g. ratios).
--   `Rad`: fixed point decimal with 45 decimals (result of integer multiplication with a `Wad` and a `Ray`).
+-   `Wad`: basic quantities (e.g. balances).
+-   `Ray`: precise quantities (e.g. ratios).
+-   `Rad`: result of multiplying `Wad` and `Ray` (highest precision).
+-   `Address`: unique identifier of an account on the network.
 
-**TODO**: Should we add operators like `+Wad` which emulate the precision limits described here, or assume the abstract model to be inifinite precision?
+**TODO**: Should we add operators like `+Wad` which emulate the precision limits described in `makerdao/dss/DEVELOPING.md`, or assume the abstract model to be inifinite precision?
 
 ```k
     syntax Wad ::= Int
@@ -27,6 +29,9 @@ Base Data
 
     syntax Rad ::= Int
  // ------------------
+
+    syntax Address ::= Int
+ // ----------------------
 ```
 
 Product Data

--- a/mkr-mcd-data.md
+++ b/mkr-mcd-data.md
@@ -29,6 +29,45 @@ Base Data
  // ------------------
 ```
 
+Product Data
+------------
+
+-   `#VatIlk`: **TODO**
+
+```k
+    syntax VatIlk ::= Ilk ( Wad , Ray , Ray , Rad , Rad ) [klabel(#VatIlk), symbol]
+ // -------------------------------------------------------------------------------
+
+    syntax Wad ::= VatIlk "." "Art" [function]
+ // ------------------------------------------
+    rule Ilk(ART, _, _, _, _) . Art => ART
+
+    syntax Ray ::= VatIlk "." "rate" [function]
+                 | VatIlk "." "spot" [function]
+ // -------------------------------------------
+    rule Ilk(_, RATE, _, _, _) . rate => RATE
+    rule Ilk(_, _, SPOT, _, _) . spot => SPOT
+
+    syntax Rad ::= VatIlk "." "line" [function]
+                 | VatIlk "." "dust" [function]
+ // -------------------------------------------
+    rule Ilk(_, _, _, LINE, _) . line => LINE
+    rule Ilk(_, _, _, _, DUST) . dust => DUST
+```
+
+-   `#VatUrn`: **TODO**
+
+```k
+    syntax VatUrn ::= Urn ( Wad , Wad ) [klabel(#VatUrn), symbol]
+ // -------------------------------------------------------------
+
+    syntax Wad ::= VatUrn "." "ink" [function]
+                 | VatUrn "." "art" [function]
+ // ------------------------------------------
+    rule Urn(INK, _) . ink => INK
+    rule Urn(_, ART) . art => ART
+```
+
 ```k
 endmodule
 ```

--- a/mkr-mcd.md
+++ b/mkr-mcd.md
@@ -55,6 +55,7 @@ Vat Semantics
 ```
 
 `Vat.rely ACCOUNT` and `Vat.deny ACCOUNT` toggle `ward [ ACCOUNT ]`.
+**TODO**: `Vat.auth` accessing the `<ward>`?
 
 ```k
     syntax VatStep ::= "rely" Address | "deny" Address

--- a/mkr-mcd.md
+++ b/mkr-mcd.md
@@ -2,8 +2,10 @@ KMCD - K Specification of MKR Multi-collateral Dai
 ==================================================
 
 ```k
+requires "mkr-mcd-data.k"
+
 module MKR-MCD
-    imports DOMAINS
+    imports MKR-MCD-DATA
 ```
 
 MCD State

--- a/mkr-mcd.md
+++ b/mkr-mcd.md
@@ -15,6 +15,20 @@ MCD State
     configuration
       <mkr-mcd>
         <k> $PGM:Pgm </k>
+        <vat>
+          <ward> .Map  </ward> // mapping (address => uint)                (actually a Bool) Int          |-> Bool
+          <can>  .Map  </can>  // mapping (address (address => uint))      (actually a Bool) Int, Int     |-> Bool
+          <ilks> .Map  </ilks> // mapping (bytes32 => VatIlk)                                Int          |-> VatIlk
+          <urns> .Map  </urns> // mapping (bytes32 => (address => VatUrn))                   Int, Address |-> VatUrn
+          <gem>  .Map  </gem>  // mapping (bytes32 => (address => uint256))                  Int, Address |-> Wad
+          <dai>  .Map  </dai>  // mapping (address => uint256)                               Address      |-> Rad
+          <sin>  .Map  </sin>  // mapping (address => uint256)                               Address      |-> Rad
+          <debt> 0:Rad </debt> // Total Dai Issued
+          <vice> 0:Rad </vice> // Total Unbacked Dai
+          <Line> 0:Rad </Line> // Total Debt Ceiling
+          <live> true  </live> // Access Flag
+        </vat>
+        <log-events> .List </log-events>
       </mkr-mcd>
 
     syntax Pgm ::= ".Pgm"

--- a/mkr-mcd.md
+++ b/mkr-mcd.md
@@ -14,7 +14,7 @@ MCD State
 ```k
     configuration
       <mkr-mcd>
-        <k> $PGM:Pgm </k>
+        <k> $PGM:MCDSteps </k>
         <vat>
           <ward> .Map  </ward> // mapping (address => uint)                (actually a Bool) Int          |-> Bool
           <can>  .Map  </can>  // mapping (address (address => uint))      (actually a Bool) Int, Int     |-> Bool
@@ -30,9 +30,40 @@ MCD State
         </vat>
         <log-events> .List </log-events>
       </mkr-mcd>
+```
 
-    syntax Pgm ::= ".Pgm"
- // ---------------------
+Simulations
+-----------
+
+Simulations will be sequences of `MCDStep`.
+
+```k
+    syntax MCDStep
+    syntax MCDSteps ::= MCDStep | MCDStep MCDSteps
+ // ----------------------------------------------
+    rule <k> MCD:MCDStep MCDS:MCDSteps => MCD ~> MCDS ... </k>
+```
+
+Vat Semantics
+-------------
+
+**TODO**: Should the `vat` map state from `address => ...` be stored as a configuration cell `<vats> <vat multiplicity="*" type="Map"> </vat> </vats>`?
+
+```k
+    syntax MCDStep ::= "Vat" "." VatStep
+ // ------------------------------------
+```
+
+`Vat.rely ACCOUNT` and `Vat.deny ACCOUNT` toggle `ward [ ACCOUNT ]`.
+
+```k
+    syntax VatStep ::= "rely" Address | "deny" Address
+ // --------------------------------------------------
+    rule <k> Vat . rely ADDR => . ... </k>
+         <ward> ... ADDR |-> (_ => true) ... </ward>
+
+    rule <k> Vat . deny ADDR => . ... </k>
+         <ward> ... ADDR |-> (_ => false) ... </ward>
 ```
 
 ```k


### PR DESCRIPTION
Questions:

-   `Wad`, `Ray`, and `Rad` are used in the specification for various operations of mixed precision. The abstract model may benefit from ignoring the precision and using unbounded integers (to model how the "ideal" system would behave).
-   I see several definitions of `struct Ilk` and `struct Urn`, with slightly different data fields. Should these be distinguished or are they morally the same? For now, I'm sorting them differently based on where they come from (ie. `VatIlk` and `VatUrn`).
-   Currently, we store several `Map` of `(address => ...)` in the `<vat>` configuration. Would we benefit by inverting the logic to have a single map of `(address => UserVat)`, where `UserVat` contains all the data relevant for that user?