### PR TITLE
control flow refactoring (preview, do not merge)

### DIFF
--- a/cdp-core.md
+++ b/cdp-core.md
@@ -153,13 +153,13 @@ Updating the `<vat>` happens in phases:
 ```k
     syntax MCDContract ::= VatContract
     syntax VatContract ::= "Vat"
-    syntax MCDStep ::= VatContract "." VatStep
- // ------------------------------------------
+    syntax MCDStep ::= VatContract "." VatStep [klabel(vatStep)]
+ // ------------------------------------------------------------
     rule contract(Vat . _) => Vat
 
     syntax VatStep ::= VatAuthStep
-    syntax AuthStep ::= VatAuthStep
- // -------------------------------
+    syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]
+ // -----------------------------------------------------------------
 ```
 
 ### Deactivation
@@ -463,13 +463,13 @@ Jug Semantics
 ```k
     syntax MCDContract ::= JugContract
     syntax JugContract ::= "Jug"
-    syntax MCDStep ::= JugContract "." JugStep
- // ------------------------------------------
+    syntax MCDStep ::= JugContract "." JugStep [klabel(jugStep)]
+ // ------------------------------------------------------------
     rule contract(Jug . _) => Jug
 
     syntax JugStep ::= JugAuthStep
-    syntax AuthStep ::= JugAuthStep
- // -------------------------------
+    syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]
+ // -----------------------------------------------------------------
 
     syntax JugStep ::= InitStep
  // ---------------------------
@@ -504,13 +504,13 @@ Cat Semantics
 ```k
     syntax MCDContract ::= CatContract
     syntax CatContract ::= "Cat"
-    syntax MCDStep ::= CatContract "." CatStep
- // ------------------------------------------
+    syntax MCDStep ::= CatContract "." CatStep [klabel(catStep)]
+ // ------------------------------------------------------------
     rule contract(Cat . _) => Cat
 
     syntax CatStep ::= CatAuthStep
-    syntax AuthStep ::= CatAuthStep
- // -------------------------------
+    syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]
+ // -----------------------------------------------------------------
 
     syntax CatAuthStep ::= "init" Address
  // -------------------------------------
@@ -528,13 +528,13 @@ Spot Semantics
 ```k
     syntax MCDContract ::= SpotContract
     syntax SpotContract ::= "Spot"
-    syntax MCDStep ::= SpotContract "." SpotStep
- // --------------------------------------------
+    syntax MCDStep ::= SpotContract "." SpotStep [klabel(spotStep)]
+ // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
 
     syntax SpotStep ::= SpotAuthStep
-    syntax AuthStep ::= SpotAuthStep
- // --------------------------------
+    syntax AuthStep ::= SpotContract "." SpotAuthStep [klabel(spotStep)]
+ // --------------------------------------------------------------------
 
     syntax SpotAuthStep ::= InitStep
  // --------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -158,31 +158,6 @@ Updating the `<vat>` happens in phases:
  // ------------------------------
 ```
 
-We can save and restore the current `<vat>` state using `push`, `pop`, and `drop`.
-This allows us to enforce properties after each step, and restore the old state when violated.
-
-```k
-    syntax VatStep ::= StashStep
- // ----------------------------
-    rule <k> Vat . push => . ... </k>
-         <vatStack> (.List => ListItem(<vat> VAT </vat>)) ... </vatStack>
-         <vat> VAT </vat>
-
-    rule <k> Vat . pop => . ... </k>
-         <vatStack> (ListItem(<vat> VAT </vat>) => .List) ... </vatStack>
-         <vat> _ => VAT </vat>
-
-    rule <k> Vat . drop => . ... </k>
-         <vatStack> (ListItem(_) => .List) ... </vatStack>
-
-    syntax VatStep ::= ExceptionStep
- // --------------------------------
-    rule <k>                     Vat . catch => Vat . drop ... </k>
-    rule <k> Vat . exception ~>  Vat . catch => Vat . pop  ... </k>
-    rule <k> Vat . exception ~> (Vat . VS    => .)         ... </k>
-      requires VS =/=K catch
-```
-
 ### Warding Control
 
 Warding allows controlling which versions of a smart contract are allowed to call into this one.
@@ -519,29 +494,6 @@ Jug Semantics
     syntax JugStep ::= JugAuthStep
  // ------------------------------
 
-    syntax JugStep ::= StashStep
- // ----------------------------
-    rule <k> Jug . push => . ... </k>
-         <jugStack> (.List => ListItem(JUG)) ... </jugStack>
-         <jug> JUG </jug>
-
-    rule <k> Jug . pop => . ... </k>
-         <jugStack> (ListItem(JUG) => .List) ... </jugStack>
-         <jug> _ => JUG </jug>
-
-    rule <k> Jug . drop => . ... </k>
-         <jugStack> (ListItem(_) => .List) ... </jugStack>
-```
-
-**TODO**: Should we make cells for call stacks and exceptions?
-```k
-    syntax JugStep ::= ExceptionStep
- // --------------------------------
-    rule <k>                     Jug . catch => Jug . drop ... </k>
-    rule <k> Jug . exception ~>  Jug . catch => Jug . pop  ... </k>
-    rule <k> Jug . exception ~> (Jug . JS    => .)         ... </k>
-      requires JS =/=K catch
-
     syntax JugStep ::= AuthStep
  // ---------------------------
     rule <k> Jug . auth => . ... </k>
@@ -606,12 +558,6 @@ Cat Semantics
     syntax CatAuthStep ::= "init" Address
  // -------------------------------------
 
-    syntax CatStep ::= StashStep
- // ----------------------------
-
-    syntax CatStep ::= ExceptionStep
- // --------------------------------
-
     syntax CatStep ::= "bite" Int Address
  // -------------------------------------
 
@@ -652,26 +598,6 @@ Spot Semantics
     rule <k> Spot . init MSGSENDER => . ... </k>
          <spot-ward> M => M[MSGSENDER <- true] </spot-ward>
          <spot-par> _ => ilk_init </spot-par>
-
-    syntax SpotStep ::= StashStep
- // -----------------------------
-    rule <k> Spot . push => . ... </k>
-         <spotStack> (.List => ListItem(SPOT)) ... </spotStack>
-         <spot> SPOT </spot>
-
-    rule <k> Spot . pop => . ... </k>
-         <spotStack> (ListItem(SPOT) => .List) ... </spotStack>
-         <spot> _ => SPOT </spot>
-
-    rule <k> Spot . drop => . ... </k>
-         <spotStack> (ListItem(_) => .List) ... </spotStack>
-
-    syntax SpotStep ::= ExceptionStep
- // ---------------------------------
-    rule <k>                      Spot . catch => Spot . drop ... </k>
-    rule <k> Spot . exception ~>  Spot . catch => Spot . pop  ... </k>
-    rule <k> Spot . exception ~> (Spot . SS    => .)          ... </k>
-      requires SS =/=K catch
 
     syntax SpotStep ::= "poke" Int
  // ------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -468,8 +468,8 @@ Jug Semantics
  // -----------------------------------------------------------------
     rule <k> Jug . _ => exception ... </k> [owise]
 
-    syntax JugStep ::= InitStep
- // ---------------------------
+    syntax JugAuthStep ::= InitStep
+ // -------------------------------
     rule <k> Jug . init ILK => . ... </k>
          <currentTime> TIME </currentTime>
          <jug-ilks> ... ILK |-> Ilk ( ILKDUTY => ilk_init, _ => TIME ) ... </jug-ilks>

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -158,37 +158,6 @@ Updating the `<vat>` happens in phases:
  // ------------------------------
 ```
 
-### Warding Control
-
-Warding allows controlling which versions of a smart contract are allowed to call into this one.
-By adjusting the `<vat-ward>`, you can upgrade contracts in place by deploying a new contract for some part of the MCD system.
-
--   `Vat.auth` checks that the given account has been `ward`ed.
--   `Vat.rely` sets authorization for a user.
--   `Vat.deny` removes authorization for a user.
-
-**TODO**: `rely` and `deny` should be `note`.
-
-```k
-    syntax VatAuthStep ::= AuthStep
- // -------------------------------
-    rule <k> Vat . auth => . ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <vat-ward> ... MSGSENDER |-> true ... </vat-ward>
-
-    rule <k> Vat . auth => Vat . exception ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <vat-ward> ... MSGSENDER |-> false ... </vat-ward>
-
-    syntax VatAuthStep ::= WardStep
- // -------------------------------
-    rule <k> Vat . rely ADDR => . ... </k>
-         <vat-ward> ... ADDR |-> (_ => true) ... </vat-ward>
-
-    rule <k> Vat . deny ADDR => . ... </k>
-         <vat-ward> ... ADDR |-> (_ => false) ... </vat-ward>
-```
-
 ### Deactivation
 
 -   `Vat.cage` disables access to this instance of MCD.
@@ -494,24 +463,6 @@ Jug Semantics
     syntax JugStep ::= JugAuthStep
  // ------------------------------
 
-    syntax JugStep ::= AuthStep
- // ---------------------------
-    rule <k> Jug . auth => . ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <jug-ward> ... MSGSENDER |-> true ... </jug-ward>
-
-    rule <k> Jug . auth => Jug . exception ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <jug-ward> ... MSGSENDER |-> false ... </jug-ward>
-
-    syntax JugAuthStep ::= WardStep
- // -------------------------------
-    rule <k> Jug . rely ADDR => . ... </k>
-         <jug-ward> ... ADDR |-> (_ => true) ... </jug-ward>
-
-    rule <k> Jug . deny ADDR => . ... </k>
-         <jug-ward> ... ADDR |-> (_ => false) ... </jug-ward>
-
     syntax JugStep ::= InitStep
  // ---------------------------
     rule <k> Jug . init ILK => . ... </k>
@@ -549,12 +500,6 @@ Cat Semantics
     syntax CatStep ::= CatAuthStep
  // ------------------------------
 
-    syntax CatAuthStep ::= AuthStep
- // -------------------------------
-
-    syntax CatAuthStep ::= WardStep
- // -------------------------------
-
     syntax CatAuthStep ::= "init" Address
  // -------------------------------------
 
@@ -574,24 +519,6 @@ Spot Semantics
 
     syntax SpotStep ::= SpotAuthStep
  // --------------------------------
-
-    syntax SpotAuthStep ::= AuthStep
- // --------------------------------
-    rule <k> Spot . auth => . ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <spot-ward> ... MSGSENDER |-> true ... </spot-ward>
-
-    rule <k> Spot . auth => Spot . exception ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <spot-ward> ... MSGSENDER |-> false ... </spot-ward>
-
-    syntax SpotAuthStep ::= WardStep
- // --------------------------------
-    rule <k> Spot . rely ADDR => . ... </k>
-         <spot-ward> ... ADDR |-> (_ => true) ... </spot-ward>
-
-    rule <k> Spot . deny ADDR => . ... </k>
-         <spot-ward> ... ADDR |-> (_ => false) ... </spot-ward>
 
     syntax SpotAuthStep ::= InitStep
  // --------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -503,9 +503,6 @@ Cat Semantics
  // -----------------------------------------------------------------
     rule <k> Cat . _ => exception ... </k> [owise]
 
-    syntax CatAuthStep ::= "init" Address
- // -------------------------------------
-
     syntax CatStep ::= "bite" Int Address
  // -------------------------------------
 
@@ -527,12 +524,6 @@ Spot Semantics
     syntax AuthStep ::= SpotContract "." SpotAuthStep [klabel(spotStep)]
  // --------------------------------------------------------------------
     rule <k> Spot . _ => exception ... </k> [owise]
-
-    syntax SpotAuthStep ::= InitStep
- // --------------------------------
-    rule <k> Spot . init MSGSENDER => . ... </k>
-         <spot-ward> M => M[MSGSENDER <- true] </spot-ward>
-         <spot-par> _ => ilk_init </spot-par>
 
     syntax SpotStep ::= "poke" Int
  // ------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -155,6 +155,7 @@ Updating the `<vat>` happens in phases:
     syntax VatContract ::= "Vat"
     syntax MCDStep ::= VatContract "." VatStep
  // ------------------------------------------
+    rule contract(Vat . _) => Vat
 
     syntax VatStep ::= VatAuthStep
  // ------------------------------
@@ -463,6 +464,7 @@ Jug Semantics
     syntax JugContract ::= "Jug"
     syntax MCDStep ::= JugContract "." JugStep
  // ------------------------------------------
+    rule contract(Jug . _) => Jug
 
     syntax JugStep ::= JugAuthStep
  // ------------------------------
@@ -502,6 +504,7 @@ Cat Semantics
     syntax CatContract ::= "Cat"
     syntax MCDStep ::= CatContract "." CatStep
  // ------------------------------------------
+    rule contract(Cat . _) => Cat
 
     syntax CatStep ::= CatAuthStep
  // ------------------------------
@@ -524,6 +527,7 @@ Spot Semantics
     syntax SpotContract ::= "Spot"
     syntax MCDStep ::= SpotContract "." SpotStep
  // --------------------------------------------
+    rule contract(Spot . _) => Spot
 
     syntax SpotStep ::= SpotAuthStep
  // --------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -153,9 +153,6 @@ Updating the `<vat>` happens in phases:
 ```k
     syntax MCDStep ::= "Vat" "." VatStep
  // ------------------------------------
-    rule <k> step [ Vat . VAS:VatAuthStep ] => Vat . push ~> Vat . auth ~> Vat . VAS ~> Vat . catch ... </k>
-    rule <k> step [ Vat . VS              ] => Vat . push ~>               Vat . VS  ~> Vat . catch ... </k>
-      requires notBool isVatAuthStep(VS)
 
     syntax VatStep ::= VatAuthStep
  // ------------------------------
@@ -518,9 +515,6 @@ Jug Semantics
 ```k
     syntax MCDStep ::= "Jug" "." JugStep
  // ------------------------------------
-    rule <k> step [ Jug . JAS:JugAuthStep ] => Jug . push ~> Jug . auth ~> Jug . JAS ~> Jug . catch ... </k>
-    rule <k> step [ Jug . JS              ] => Jug . push ~>               Jug . JS  ~> Jug . catch ... </k>
-      requires notBool isJugAuthStep(JS)
 
     syntax JugStep ::= JugAuthStep
  // ------------------------------
@@ -631,9 +625,6 @@ Spot Semantics
 ```k
     syntax MCDStep ::= "Spot" "." SpotStep
  // --------------------------------------
-    rule <k> step [ Spot . SAS:SpotAuthStep ] => Spot . push ~> Spot . auth ~> Spot . SAS ~> Spot . catch ... </k>
-    rule <k> step [ Spot . SS               ] => Spot . push ~>                Spot . SS  ~> Spot . catch ... </k>
-      requires notBool isSpotAuthStep(SS)
 
     syntax SpotStep ::= SpotAuthStep
  // --------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -89,29 +89,33 @@ Vat CDP State
     configuration
       <cdp-core>
         <vat>
-          <vat-can>  .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
-          <vat-ilks> .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  Int     |-> VatIlk
-          <vat-urns> .Map  </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
-          <vat-gem>  .Map  </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
-          <vat-dai>  .Map  </vat-dai>  // mapping (address => uint256)              Address |-> Rad
-          <vat-sin>  .Map  </vat-sin>  // mapping (address => uint256)              Address |-> Rad
-          <vat-debt> 0:Rad </vat-debt> // Total Dai Issued
-          <vat-vice> 0:Rad </vat-vice> // Total Unbacked Dai
-          <vat-Line> 0:Rad </vat-Line> // Total Debt Ceiling
-          <vat-live> true  </vat-live> // Access Flag
+          <vat-addr> 0:Address </vat-addr>
+          <vat-can>  .Map      </vat-can>  // mapping (address (address => uint))       Address |-> Set
+          <vat-ilks> .Map      </vat-ilks> // mapping (bytes32 => Ilk)                  Int     |-> VatIlk
+          <vat-urns> .Map      </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
+          <vat-gem>  .Map      </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
+          <vat-dai>  .Map      </vat-dai>  // mapping (address => uint256)              Address |-> Rad
+          <vat-sin>  .Map      </vat-sin>  // mapping (address => uint256)              Address |-> Rad
+          <vat-debt> 0:Rad     </vat-debt> // Total Dai Issued
+          <vat-vice> 0:Rad     </vat-vice> // Total Unbacked Dai
+          <vat-Line> 0:Rad     </vat-Line> // Total Debt Ceiling
+          <vat-live> true      </vat-live> // Access Flag
         </vat>
         <jug>
+          <jug-addr> 0:Address </jug-addr>
           <jug-ilks> .Map      </jug-ilks> // mapping (bytes32 => JugIlk) Int     |-> JugIlk
           <jug-vow>  0:Address </jug-vow>  //                             Address
           <jug-base> 0         </jug-base> //                             Int
         </jug>
         <cat>
-          <cat-ilks> .Map </cat-ilks>
-          <cat-live> 1    </cat-live>
+          <cat-addr> 0:Address </cat-addr>
+          <cat-ilks> .Map      </cat-ilks>
+          <cat-live> 1         </cat-live>
         </cat>
         <spot>
-          <spot-ilks> .Map </spot-ilks> // mapping (bytes32 => ilk)  Int     |-> SpotIlk
-          <spot-par>  0    </spot-par>
+          <spot-addr> 0:Address </spot-addr>
+          <spot-ilks> .Map      </spot-ilks> // mapping (bytes32 => ilk)  Int     |-> SpotIlk
+          <spot-par>  0         </spot-par>
         </spot>
       </cdp-core>
 ```

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -217,7 +217,6 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatStep ::= "safe" Int Address
  // -------------------------------------
-    rule <k> Vat . safe ILKID ADDR => Vat . exception ... </k> [owise]
     rule <k> Vat . safe ILKID ADDR => .               ... </k>
          <vat>
            <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
@@ -229,7 +228,6 @@ This is quite permissive, and would allow the account to drain all your locked c
 
     syntax VatStep ::= "nondusty" Int Address
  // -----------------------------------------
-    rule <k> Vat . nondusty ILKID ADDR => Vat . exception ... </k> [owise]
     rule <k> Vat . nondusty ILKID ADDR => .               ... </k>
          <vat>
            <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
@@ -251,9 +249,6 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . init ILKID => . ... </k>
          <vat-ilks> ILKS => ILKS [ ILKID <- ilk_init ] </vat-ilks>
       requires notBool ILKID in_keys(ILKS)
-
-    rule <k> Vat . init ILKID => Vat . exception ... </k>
-         <vat-ilks> ... ILKID |-> _ ... </vat-ilks>
 ```
 
 ### Collateral manipulation (`<vat-gem>`)
@@ -477,8 +472,6 @@ Jug Semantics
          <currentTime> TIME </currentTime>
          <jug-ilks> ... ILK |-> Ilk ( ILKDUTY => ilk_init, _ => TIME ) ... </jug-ilks>
       requires ILKDUTY ==Int 0
-
-    rule <k> Jug . init _ => Jug . exception ... </k> [owise]
 ```
 
 ```k
@@ -491,11 +484,6 @@ Jug Semantics
          <jug-vow> ADDRESS </jug-vow>
          <jug-base> BASE </jug-base>
       requires TIME >=Int ILKRHO
-
-    rule <k> Jug . drip ILK => Jug . exception ... </k>
-         <currentTime> TIME </currentTime>
-         <jug-ilks> ... ILK |-> Ilk ( _, ILKRHO ) ... </jug-ilks>
-      requires TIME <Int ILKRHO
 ```
 
 Cat Semantics

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -516,6 +516,7 @@ Spot Semantics
  // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
 
+    syntax SpotAuthStep
     syntax SpotStep ::= SpotAuthStep
     syntax AuthStep ::= SpotContract "." SpotAuthStep [klabel(spotStep)]
  // --------------------------------------------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -160,6 +160,7 @@ Updating the `<vat>` happens in phases:
     syntax VatStep ::= VatAuthStep
     syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]
  // -----------------------------------------------------------------
+    rule <k> Vat . _ => exception ... </k> [owise]
 ```
 
 ### Deactivation
@@ -465,6 +466,7 @@ Jug Semantics
     syntax JugStep ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]
  // -----------------------------------------------------------------
+    rule <k> Jug . _ => exception ... </k> [owise]
 
     syntax JugStep ::= InitStep
  // ---------------------------
@@ -499,6 +501,7 @@ Cat Semantics
     syntax CatStep ::= CatAuthStep
     syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]
  // -----------------------------------------------------------------
+    rule <k> Cat . _ => exception ... </k> [owise]
 
     syntax CatAuthStep ::= "init" Address
  // -------------------------------------
@@ -523,6 +526,7 @@ Spot Semantics
     syntax SpotStep ::= SpotAuthStep
     syntax AuthStep ::= SpotContract "." SpotAuthStep [klabel(spotStep)]
  // --------------------------------------------------------------------
+    rule <k> Spot . _ => exception ... </k> [owise]
 
     syntax SpotAuthStep ::= InitStep
  // --------------------------------

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -152,6 +152,7 @@ Updating the `<vat>` happens in phases:
     syntax MCDStep ::= VatContract "." VatStep [klabel(vatStep)]
  // ------------------------------------------------------------
     rule contract(Vat . _) => Vat
+    rule [[ address(Vat) => ADDR ]] <vat-addr> ADDR </vat-addr>
 
     syntax VatStep ::= VatAuthStep
     syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]
@@ -458,6 +459,7 @@ Jug Semantics
     syntax MCDStep ::= JugContract "." JugStep [klabel(jugStep)]
  // ------------------------------------------------------------
     rule contract(Jug . _) => Jug
+    rule [[ address(Jug) => ADDR ]] <jug-addr> ADDR </jug-addr>
 
     syntax JugStep ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]
@@ -493,6 +495,7 @@ Cat Semantics
     syntax MCDStep ::= CatContract "." CatStep [klabel(catStep)]
  // ------------------------------------------------------------
     rule contract(Cat . _) => Cat
+    rule [[ address(Cat) => ADDR ]] <cat-addr> ADDR </cat-addr>
 
     syntax CatStep ::= CatAuthStep
     syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]
@@ -515,6 +518,7 @@ Spot Semantics
     syntax MCDStep ::= SpotContract "." SpotStep [klabel(spotStep)]
  // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
+    rule [[ address(Spot) => ADDR ]] <spot-addr> ADDR </spot-addr>
 
     syntax SpotAuthStep
     syntax SpotStep ::= SpotAuthStep

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -158,7 +158,8 @@ Updating the `<vat>` happens in phases:
     rule contract(Vat . _) => Vat
 
     syntax VatStep ::= VatAuthStep
- // ------------------------------
+    syntax AuthStep ::= VatAuthStep
+ // -------------------------------
 ```
 
 ### Deactivation
@@ -467,7 +468,8 @@ Jug Semantics
     rule contract(Jug . _) => Jug
 
     syntax JugStep ::= JugAuthStep
- // ------------------------------
+    syntax AuthStep ::= JugAuthStep
+ // -------------------------------
 
     syntax JugStep ::= InitStep
  // ---------------------------
@@ -507,7 +509,8 @@ Cat Semantics
     rule contract(Cat . _) => Cat
 
     syntax CatStep ::= CatAuthStep
- // ------------------------------
+    syntax AuthStep ::= CatAuthStep
+ // -------------------------------
 
     syntax CatAuthStep ::= "init" Address
  // -------------------------------------
@@ -530,6 +533,7 @@ Spot Semantics
     rule contract(Spot . _) => Spot
 
     syntax SpotStep ::= SpotAuthStep
+    syntax AuthStep ::= SpotAuthStep
  // --------------------------------
 
     syntax SpotAuthStep ::= InitStep

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -88,7 +88,6 @@ Vat CDP State
 ```k
     configuration
       <cdp-core>
-        <vatStack> .List </vatStack>
         <vat>
           <vat-can>  .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
           <vat-ilks> .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  Int     |-> VatIlk
@@ -101,18 +100,15 @@ Vat CDP State
           <vat-Line> 0:Rad </vat-Line> // Total Debt Ceiling
           <vat-live> true  </vat-live> // Access Flag
         </vat>
-        <jugStack> .List </jugStack>
         <jug>
           <jug-ilks> .Map      </jug-ilks> // mapping (bytes32 => JugIlk) Int     |-> JugIlk
           <jug-vow>  0:Address </jug-vow>  //                             Address
           <jug-base> 0         </jug-base> //                             Int
         </jug>
-        <catStack> .List </catStack>
         <cat>
           <cat-ilks> .Map </cat-ilks>
           <cat-live> 1    </cat-live>
         </cat>
-        <spotStack> .List </spotStack>
         <spot>
           <spot-ilks> .Map </spot-ilks> // mapping (bytes32 => ilk)  Int     |-> SpotIlk
           <spot-par>  0    </spot-par>

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -90,7 +90,6 @@ Vat CDP State
       <cdp-core>
         <vatStack> .List </vatStack>
         <vat>
-          <vat-ward> .Map  </vat-ward> // mapping (address => uint)                 Address |-> Bool
           <vat-can>  .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
           <vat-ilks> .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  Int     |-> VatIlk
           <vat-urns> .Map  </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
@@ -104,20 +103,17 @@ Vat CDP State
         </vat>
         <jugStack> .List </jugStack>
         <jug>
-          <jug-ward> .Map      </jug-ward> // mapping (address => uint)   Address |-> Bool
           <jug-ilks> .Map      </jug-ilks> // mapping (bytes32 => JugIlk) Int     |-> JugIlk
           <jug-vow>  0:Address </jug-vow>  //                             Address
           <jug-base> 0         </jug-base> //                             Int
         </jug>
         <catStack> .List </catStack>
         <cat>
-          <cat-ward> .Map </cat-ward>
           <cat-ilks> .Map </cat-ilks>
           <cat-live> 1    </cat-live>
         </cat>
         <spotStack> .List </spotStack>
         <spot>
-          <spot-ward> .Map </spot-ward> // mapping (address => uint) Address |-> Bool
           <spot-ilks> .Map </spot-ilks> // mapping (bytes32 => ilk)  Int     |-> SpotIlk
           <spot-par>  0    </spot-par>
         </spot>

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -502,8 +502,8 @@ Cat Semantics
     syntax CatStep ::= "bite" Int Address
  // -------------------------------------
 
-    syntax CatStep ::= "cage" [klabel(#CatCage), symbol]
- // ----------------------------------------------------
+    syntax CatAuthStep ::= "cage" [klabel(#CatCage), symbol]
+ // --------------------------------------------------------
 ```
 
 Spot Semantics

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -477,7 +477,7 @@ Jug Semantics
 ```k
     syntax JugStep ::= "drip" Int
  // -----------------------------
-    rule <k> Jug . drip ILK => Vat . fold ILK ADDRESS ( #pow( BASE +Int ILKDUTY, TIME -Int ILKRHO ) *Int ILKRATE ) -Int ILKRATE ... </k>
+    rule <k> Jug . drip ILK => call Vat . fold ILK ADDRESS ( #pow( BASE +Int ILKDUTY, TIME -Int ILKRHO ) *Int ILKRATE ) -Int ILKRATE ... </k>
          <currentTime> TIME </currentTime>
          <vat-ilks> ... ILK |-> Ilk ( _, ILKRATE, _, _, _ ) ... </vat-ilks>
          <jug-ilks> ... ILK |-> Ilk ( ILKDUTY, ILKRHO => TIME ) ... </jug-ilks>

--- a/cdp-core.md
+++ b/cdp-core.md
@@ -151,8 +151,10 @@ Updating the `<vat>` happens in phases:
 **TODO**: Should every `notBool isAuthStep` be subject to `Vat . live`?
 
 ```k
-    syntax MCDStep ::= "Vat" "." VatStep
- // ------------------------------------
+    syntax MCDContract ::= VatContract
+    syntax VatContract ::= "Vat"
+    syntax MCDStep ::= VatContract "." VatStep
+ // ------------------------------------------
 
     syntax VatStep ::= VatAuthStep
  // ------------------------------
@@ -457,8 +459,10 @@ Jug Semantics
 -------------
 
 ```k
-    syntax MCDStep ::= "Jug" "." JugStep
- // ------------------------------------
+    syntax MCDContract ::= JugContract
+    syntax JugContract ::= "Jug"
+    syntax MCDStep ::= JugContract "." JugStep
+ // ------------------------------------------
 
     syntax JugStep ::= JugAuthStep
  // ------------------------------
@@ -494,8 +498,10 @@ Cat Semantics
 -------------
 
 ```k
-    syntax MCDStep ::= "Cat" "." CatStep
- // ------------------------------------
+    syntax MCDContract ::= CatContract
+    syntax CatContract ::= "Cat"
+    syntax MCDStep ::= CatContract "." CatStep
+ // ------------------------------------------
 
     syntax CatStep ::= CatAuthStep
  // ------------------------------
@@ -514,8 +520,10 @@ Spot Semantics
 --------------
 
 ```k
-    syntax MCDStep ::= "Spot" "." SpotStep
- // --------------------------------------
+    syntax MCDContract ::= SpotContract
+    syntax SpotContract ::= "Spot"
+    syntax MCDStep ::= SpotContract "." SpotStep
+ // --------------------------------------------
 
     syntax SpotStep ::= SpotAuthStep
  // --------------------------------

--- a/collateral.md
+++ b/collateral.md
@@ -34,10 +34,6 @@ module COLLATERAL
 
     syntax MCDStep ::= "Flip" Int "." FlipStep
  // ------------------------------------------
-    rule <k> step [ Flip F . FAS:FlipAuthStep ] => Flip F . push ~> Flip F . auth ~> Flip F . FAS ~> Flip F . catch ... </k>
-    rule <k> step [ Flip F . FS               ] => Flip F . push ~>                  Flip F . FS  ~> Flip F . catch ... </k>
-      requires notBool isFlipAuthStep(FS)
-
 
     syntax FlipStep ::= FlipAuthStep
  // --------------------------------

--- a/collateral.md
+++ b/collateral.md
@@ -41,6 +41,7 @@ module COLLATERAL
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]
  // --------------------------------------------------------------------
+    rule <k> Flip _ . _ => exception ... </k> [owise]
 
     syntax FlipStep ::= "kick" Address Address Int Int Int
  // ------------------------------------------------------

--- a/collateral.md
+++ b/collateral.md
@@ -16,6 +16,7 @@ module COLLATERAL
         <flips>
           <flip multiplicity="*" type="Map">
             <flip-ilk>   0            </flip-ilk>
+            <flip-addr>  0:Address    </flip-addr>
             <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> Bid
             <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
             <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime

--- a/collateral.md
+++ b/collateral.md
@@ -142,8 +142,8 @@ module COLLATERAL
       requires TIC =/=Int 0
        andBool (TIC <Int NOW orBool END <Int NOW)
 
-    syntax FlipStep ::= "yank" Int
- // ------------------------------
+    syntax FlipAuthStep ::= "yank" Int
+ // ----------------------------------
     rule <k> Flip ILK . yank ID
           => Vat . flux ILK THIS MSGSENDER LOT
           ~> Vat . move MSGSENDER GUY BID ... </k>

--- a/collateral.md
+++ b/collateral.md
@@ -18,7 +18,6 @@ module COLLATERAL
             <flip-ilk> 0 </flip-ilk>
             <flipStack> .List </flipStack>
             <flip>
-              <flip-ward>  .Map         </flip-ward> // mapping (address => uint) Address |-> Bool
               <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> Bid
               <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
               <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime

--- a/collateral.md
+++ b/collateral.md
@@ -34,6 +34,7 @@ module COLLATERAL
     syntax MCDStep ::= FlipContract "." FlipStep [klabel(flipStep)]
  // ---------------------------------------------------------------
     rule contract(Flip ILK . _) => Flip ILK
+    rule [[ address(Flip ILK) => ADDR ]] <flip-ilk> ILK </flip-ilk> <flip-addr> ADDR </flip-addr>
 
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]

--- a/collateral.md
+++ b/collateral.md
@@ -38,12 +38,6 @@ module COLLATERAL
     syntax FlipStep ::= FlipAuthStep
  // --------------------------------
 
-    syntax FlipAuthStep ::= AuthStep
- // --------------------------------
-
-    syntax FlipAuthStep ::= WardStep
- // --------------------------------
-
     syntax FlipStep ::= "kick" Address Address Int Int Int
  // ------------------------------------------------------
     rule <k> Flip ILK . kick USR GAL TAB LOT BID

--- a/collateral.md
+++ b/collateral.md
@@ -44,7 +44,7 @@ module COLLATERAL
     syntax FlipStep ::= "kick" Address Address Int Int Int
  // ------------------------------------------------------
     rule <k> Flip ILK . kick USR GAL TAB LOT BID
-          => Vat . flux ILK MSGSENDER THIS LOT
+          => call Vat . flux ILK MSGSENDER THIS LOT
           ~> KICKS +Int 1 ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
@@ -79,8 +79,8 @@ module COLLATERAL
     syntax FlipStep ::= "tend" Int Int Int
  // --------------------------------------
     rule <k> Flip ILK . tend ID LOT BID
-          => Vat . move MSGSENDER GUY BID'
-          ~> Vat . move MSGSENDER GAL (BID -Int BID') ... </k>
+          => call Vat . move MSGSENDER GUY BID'
+          ~> call Vat . move MSGSENDER GAL (BID -Int BID') ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <currentTime> NOW </currentTime>
          <flip-ilk> ILK </flip-ilk>
@@ -106,8 +106,8 @@ module COLLATERAL
     syntax FlipStep ::= "dent" Int Int Int
  // --------------------------------------
     rule <k> Flip ILK . dent ID LOT BID
-          => Vat.move MSGSENDER GUY BID
-          ~> Vat.flux ILK THIS USR (LOT' -Int LOT) ... </k>
+          => call Vat.move MSGSENDER GUY BID
+          ~> call Vat.flux ILK THIS USR (LOT' -Int LOT) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <currentTime> NOW </currentTime>
@@ -133,7 +133,7 @@ module COLLATERAL
 
     syntax FlipStep ::= "deal" Int
  // ------------------------------
-    rule <k> Flip ILK . deal ID => Vat . flux ILK THIS GUY LOT ... </k>
+    rule <k> Flip ILK . deal ID => call Vat . flux ILK THIS GUY LOT ... </k>
          <this> THIS </this>
          <currentTime> NOW </currentTime>
          <flip-ilk> ILK </flip-ilk>
@@ -146,8 +146,8 @@ module COLLATERAL
     syntax FlipAuthStep ::= "yank" Int
  // ----------------------------------
     rule <k> Flip ILK . yank ID
-          => Vat . flux ILK THIS MSGSENDER LOT
-          ~> Vat . move MSGSENDER GUY BID ... </k>
+          => call Vat . flux ILK THIS MSGSENDER LOT
+          ~> call Vat . move MSGSENDER GUY BID ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <flip-ilk> ILK </flip-ilk>

--- a/collateral.md
+++ b/collateral.md
@@ -34,13 +34,13 @@ module COLLATERAL
 
     syntax MCDContract ::= FlipContract
     syntax FlipContract ::= "Flip" Int
-    syntax MCDStep ::= FlipContract "." FlipStep
- // --------------------------------------------
+    syntax MCDStep ::= FlipContract "." FlipStep [klabel(flipStep)]
+ // ---------------------------------------------------------------
     rule contract(Flip ILK . _) => Flip ILK
 
     syntax FlipStep ::= FlipAuthStep
-    syntax AuthStep ::= FlipAuthStep
- // --------------------------------
+    syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]
+ // --------------------------------------------------------------------
 
     syntax FlipStep ::= "kick" Address Address Int Int Int
  // ------------------------------------------------------

--- a/collateral.md
+++ b/collateral.md
@@ -16,7 +16,6 @@ module COLLATERAL
         <flippers>
           <flipper multiplicity="*" type="Map">
             <flip-ilk> 0 </flip-ilk>
-            <flipStack> .List </flipStack>
             <flip>
               <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> Bid
               <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase

--- a/collateral.md
+++ b/collateral.md
@@ -44,12 +44,6 @@ module COLLATERAL
     syntax FlipAuthStep ::= WardStep
  // --------------------------------
 
-    syntax FlipStep ::= StashStep
- // -----------------------------
-
-    syntax FlipStep ::= ExceptionStep
- // ---------------------------------
-
     syntax FlipStep ::= "kick" Address Address Int Int Int
  // ------------------------------------------------------
     rule <k> Flip ILK . kick USR GAL TAB LOT BID

--- a/collateral.md
+++ b/collateral.md
@@ -13,18 +13,16 @@ module COLLATERAL
 
     configuration
       <collateral>
-        <flippers>
-          <flipper multiplicity="*" type="Map">
-            <flip-ilk> 0 </flip-ilk>
-            <flip>
-              <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> Bid
-              <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
-              <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime
-              <flip-tau>   2 days       </flip-tau>  // Total Auction Length
-              <flip-kicks> 0            </flip-kicks>
-            </flip>
-          </flipper>
-        </flippers>
+        <flips>
+          <flip multiplicity="*" type="Map">
+            <flip-ilk>   0            </flip-ilk>
+            <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> Bid
+            <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
+            <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime
+            <flip-tau>   2 days       </flip-tau>  // Total Auction Length
+            <flip-kicks> 0            </flip-kicks>
+          </flip>
+        </flips>
       </collateral>
 
     syntax Bid ::= Bid ( bid: Int, lot: Int, guy: Address, tic: Int, end: Int, usr: Address, gal: Address, tab: Int )

--- a/collateral.md
+++ b/collateral.md
@@ -32,8 +32,10 @@ module COLLATERAL
     syntax Bid ::= Bid ( bid: Int, lot: Int, guy: Address, tic: Int, end: Int, usr: Address, gal: Address, tab: Int )
  // -----------------------------------------------------------------------------------------------------------------
 
-    syntax MCDStep ::= "Flip" Int "." FlipStep
- // ------------------------------------------
+    syntax MCDContract ::= FlipContract
+    syntax FlipContract ::= "Flip" Int
+    syntax MCDStep ::= FlipContract "." FlipStep
+ // --------------------------------------------
 
     syntax FlipStep ::= FlipAuthStep
  // --------------------------------

--- a/collateral.md
+++ b/collateral.md
@@ -39,6 +39,7 @@ module COLLATERAL
     rule contract(Flip ILK . _) => Flip ILK
 
     syntax FlipStep ::= FlipAuthStep
+    syntax AuthStep ::= FlipAuthStep
  // --------------------------------
 
     syntax FlipStep ::= "kick" Address Address Int Int Int

--- a/collateral.md
+++ b/collateral.md
@@ -36,6 +36,7 @@ module COLLATERAL
     syntax FlipContract ::= "Flip" Int
     syntax MCDStep ::= FlipContract "." FlipStep
  // --------------------------------------------
+    rule contract(Flip ILK . _) => Flip ILK
 
     syntax FlipStep ::= FlipAuthStep
  // --------------------------------

--- a/dai.md
+++ b/dai.md
@@ -36,6 +36,7 @@ module DAI
     syntax DaiStep ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]
  // -----------------------------------------------------------------
+    rule <k> Dai . _ => exception ... </k> [owise]
 
     syntax DaiAuthStep ::= "init" Int
  // ---------------------------------

--- a/dai.md
+++ b/dai.md
@@ -15,7 +15,6 @@ module DAI
       <dai>
         <dai-stack> .List </dai-stack>
         <dai-state>
-          <dai-ward>        .Map </dai-ward>        // mapping (address => uint)                      Address |-> Bool
           <dai-totalSupply> 0    </dai-totalSupply>
           <dai-account-id>  0    </dai-account-id>
           <dai-balance>     .Map </dai-balance>     // mapping (address => uint)                      Address |-> Int

--- a/dai.md
+++ b/dai.md
@@ -100,8 +100,8 @@ module DAI
       requires ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Int AMOUNT
 
-    syntax DaiStep ::= "mint" Address Wad
- // -------------------------------------
+    syntax DaiAuthStep ::= "mint" Address Wad
+ // -----------------------------------------
     rule <k> Dai . mint ACCOUNT_DST AMOUNT => . ... </k>
          <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY +Int AMOUNT </dai-totalSupply>
          <dai-balance>

--- a/dai.md
+++ b/dai.md
@@ -13,7 +13,6 @@ module DAI
 
     configuration
       <dai>
-        <dai-stack> .List </dai-stack>
         <dai-state>
           <dai-totalSupply> 0    </dai-totalSupply>
           <dai-account-id>  0    </dai-account-id>

--- a/dai.md
+++ b/dai.md
@@ -29,13 +29,13 @@ module DAI
 
     syntax MCDContract ::= DaiContract
     syntax DaiContract ::= "Dai"
-    syntax MCDStep ::= DaiContract "." DaiStep
- // ------------------------------------------
+    syntax MCDStep ::= DaiContract "." DaiStep [klabel(daiStep)]
+ // ------------------------------------------------------------
     rule contract(Dai . _) => Dai
 
     syntax DaiStep ::= DaiAuthStep
-    syntax AuthStep ::= DaiAuthStep
- // -------------------------------
+    syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]
+ // -----------------------------------------------------------------
 
     syntax DaiAuthStep ::= "init" Int
  // ---------------------------------

--- a/dai.md
+++ b/dai.md
@@ -33,12 +33,6 @@ module DAI
     syntax DaiStep ::= DaiAuthStep
  // ------------------------------
 
-    syntax DaiAuthStep ::= AuthStep
- // -------------------------------
-
-    syntax DaiAuthStep ::= WardStep
- // -------------------------------
-
     syntax DaiAuthStep ::= "init" Int
  // ---------------------------------
 

--- a/dai.md
+++ b/dai.md
@@ -31,6 +31,7 @@ module DAI
     syntax DaiContract ::= "Dai"
     syntax MCDStep ::= DaiContract "." DaiStep
  // ------------------------------------------
+    rule contract(Dai . _) => Dai
 
     syntax DaiStep ::= DaiAuthStep
  // ------------------------------

--- a/dai.md
+++ b/dai.md
@@ -27,8 +27,10 @@ module DAI
     syntax AllowanceAddress ::= "{" Address "->" Address "}"
  // --------------------------------------------------------
 
-    syntax MCDStep ::= "Dai" "." DaiStep
- // ------------------------------------
+    syntax MCDContract ::= DaiContract
+    syntax DaiContract ::= "Dai"
+    syntax MCDStep ::= DaiContract "." DaiStep
+ // ------------------------------------------
 
     syntax DaiStep ::= DaiAuthStep
  // ------------------------------

--- a/dai.md
+++ b/dai.md
@@ -34,7 +34,8 @@ module DAI
     rule contract(Dai . _) => Dai
 
     syntax DaiStep ::= DaiAuthStep
- // ------------------------------
+    syntax AuthStep ::= DaiAuthStep
+ // -------------------------------
 
     syntax DaiAuthStep ::= "init" Int
  // ---------------------------------

--- a/dai.md
+++ b/dai.md
@@ -31,6 +31,7 @@ module DAI
     syntax MCDStep ::= DaiContract "." DaiStep [klabel(daiStep)]
  // ------------------------------------------------------------
     rule contract(Dai . _) => Dai
+    rule [[ address(Dai) => ADDR ]] <dai-addr> ADDR </dai-addr>
 
     syntax DaiStep ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]

--- a/dai.md
+++ b/dai.md
@@ -42,13 +42,6 @@ module DAI
     syntax DaiAuthStep ::= "init" Int
  // ---------------------------------
 
-    syntax DaiStep ::= StashStep
- // ----------------------------
-
-    syntax DaiStep ::= ExceptionStep
- // --------------------------------
-    rule <k> Dai . _:DaiStep => Dai . exception ... </k> [owise]
-
     syntax DaiStep ::= "transfer" Address Wad
  // -----------------------------------------
     rule <k> Dai . transfer ACCOUNT_SRC AMOUNT => . ... </k>

--- a/dai.md
+++ b/dai.md
@@ -14,11 +14,12 @@ module DAI
     configuration
       <dai>
         <dai-state>
-          <dai-totalSupply> 0    </dai-totalSupply>
-          <dai-account-id>  0    </dai-account-id>
-          <dai-balance>     .Map </dai-balance>     // mapping (address => uint)                      Address |-> Int
-          <dai-allowance>   .Map </dai-allowance>   // mapping (address => mapping (address => uint))
-          <dai-nonce>       .Map </dai-nonce>       // mapping (address => uint)                      Address |-> Int
+          <dai-addr>        0:Address </dai-addr>
+          <dai-totalSupply> 0         </dai-totalSupply>
+          <dai-account-id>  0         </dai-account-id>
+          <dai-balance>     .Map      </dai-balance>     // mapping (address => uint)                      Address |-> Int
+          <dai-allowance>   .Map      </dai-allowance>   // mapping (address => mapping (address => uint))
+          <dai-nonce>       .Map      </dai-nonce>       // mapping (address => uint)                      Address |-> Int
         </dai-state>
       </dai>
 

--- a/dai.md
+++ b/dai.md
@@ -38,9 +38,6 @@ module DAI
  // -----------------------------------------------------------------
     rule <k> Dai . _ => exception ... </k> [owise]
 
-    syntax DaiAuthStep ::= "init" Int
- // ---------------------------------
-
     syntax DaiStep ::= "transfer" Address Wad
  // -----------------------------------------
     rule <k> Dai . transfer ACCOUNT_SRC AMOUNT => . ... </k>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -33,6 +33,7 @@ MCD Simulations
     rule <k> MCD:MCDStep MCDS:MCDSteps => MCD ~> MCDS ... </k>
 
     syntax MCDContract ::= contract(MCDStep) [function]
+    syntax Address ::= address(MCDContract) [function]
  // ---------------------------------------------------
 ```
 

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -48,12 +48,6 @@ Different contracts use the same names for external functions, so we declare the
 
     syntax AuthStep ::= "auth"
  // --------------------------
-
-    syntax StashStep ::= "push" | "pop" | "drop"
- // --------------------------------------------
-
-    syntax ExceptionStep ::= "catch" | "exception"
- // ----------------------------------------------
 ```
 
 Time Increments

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -27,11 +27,13 @@ MCD Simulations
 ---------------
 
 ```k
-    syntax MCDStep
     syntax MCDSteps ::= ".MCDSteps" | MCDStep MCDSteps
  // --------------------------------------------------
     rule <k> .MCDSteps => . ... </k>
     rule <k> MCD:MCDStep MCDS:MCDSteps => MCD ~> MCDS ... </k>
+
+    syntax MCDContract
+ // ------------------
 ```
 
 Simulations

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -42,12 +42,6 @@ Different contracts use the same names for external functions, so we declare the
 ```k
     syntax InitStep ::= "init" Int
  // ------------------------------
-
-    syntax WardStep ::= "rely" Address | "deny" Address
- // ---------------------------------------------------
-
-    syntax AuthStep ::= "auth"
- // --------------------------
 ```
 
 Time Increments

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -32,8 +32,8 @@ MCD Simulations
     rule <k> .MCDSteps => . ... </k>
     rule <k> MCD:MCDStep MCDS:MCDSteps => MCD ~> MCDS ... </k>
 
-    syntax MCDContract
- // ------------------
+    syntax MCDContract ::= contract(MCDStep) [function]
+ // ---------------------------------------------------
 ```
 
 Simulations

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -31,14 +31,7 @@ MCD Simulations
     syntax MCDSteps ::= ".MCDSteps" | MCDStep MCDSteps
  // --------------------------------------------------
     rule <k> .MCDSteps => . ... </k>
-```
-
-The `step [_]` operator allows enforcing certain invariants during execution.
-
-```k
-    syntax MCDStep ::= "step" "[" MCDStep "]"
- // -----------------------------------------
-    rule <k> MCD:MCDStep MCDS:MCDSteps => step [ MCD ] ~> MCDS ... </k>
+    rule <k> MCD:MCDStep MCDS:MCDSteps => MCD ~> MCDS ... </k>
 ```
 
 Simulations
@@ -71,7 +64,7 @@ Some methods rely on a timestamp. We simulate that here.
 ```k
     syntax MCDStep ::= "TimeStep"
  // -----------------------------
-    rule <k> step [ TimeStep ] => . ... </k>
+    rule <k> TimeStep => . ... </k>
          <currentTime> TIME => TIME +Int 1 second </currentTime>
 
     syntax Int ::= Int "second"  [timeUnit]

--- a/kmcd.md
+++ b/kmcd.md
@@ -61,6 +61,7 @@ End Semantics
     syntax EndContract ::= "End"
     syntax MCDStep ::= EndContract "." EndStep
  // ------------------------------------------
+    rule contract(End . _) => End
 
     syntax EndStep ::= EndAuthStep
  // ------------------------------

--- a/kmcd.md
+++ b/kmcd.md
@@ -38,16 +38,17 @@ module KMCD
           <rates/>
           <endPhase> false </endPhase>
           <end>
-            <end-live> 0    </end-live>
-            <end-when> 0    </end-when>
-            <end-wait> 0    </end-wait>
-            <end-debt> 0    </end-debt>
-            <end-tag>  .Map </end-tag>  // mapping (bytes32 => uint256)                      Int     |-> Ray
-            <end-gap>  .Map </end-gap>  // mapping (bytes32 => uint256)                      Int     |-> Wad
-            <end-art>  .Map </end-art>  // mapping (bytes32 => uint256)                      Int     |-> Wad
-            <end-fix>  .Map </end-fix>  // mapping (bytes32 => uint256)                      Int     |-> Ray
-            <end-bag>  .Map </end-bag>  // mapping (address => uint256)                      Int     |-> Wad
-            <end-out>  .Map </end-out>  // mapping (bytes32 => mapping (address => uint256)) Int     |-> Wad
+            <end-addr> 0:Address </end-addr>
+            <end-live> 0         </end-live>
+            <end-when> 0         </end-when>
+            <end-wait> 0         </end-wait>
+            <end-debt> 0         </end-debt>
+            <end-tag>  .Map      </end-tag>  // mapping (bytes32 => uint256)                      Int     |-> Ray
+            <end-gap>  .Map      </end-gap>  // mapping (bytes32 => uint256)                      Int     |-> Wad
+            <end-art>  .Map      </end-art>  // mapping (bytes32 => uint256)                      Int     |-> Wad
+            <end-fix>  .Map      </end-fix>  // mapping (bytes32 => uint256)                      Int     |-> Ray
+            <end-bag>  .Map      </end-bag>  // mapping (address => uint256)                      Int     |-> Wad
+            <end-out>  .Map      </end-out>  // mapping (bytes32 => mapping (address => uint256)) Int     |-> Wad
           </end>
         </kmcd-state>
       </kmcd>

--- a/kmcd.md
+++ b/kmcd.md
@@ -63,12 +63,6 @@ End Semantics
     syntax EndStep ::= EndAuthStep
  // ------------------------------
 
-    syntax EndAuthStep ::= AuthStep
- // -------------------------------
-
-    syntax EndAuthStep ::= WardStep
- // -------------------------------
-
     syntax EndAuthStep ::= "init"
  // -----------------------------
 

--- a/kmcd.md
+++ b/kmcd.md
@@ -69,6 +69,7 @@ End Semantics
 
     syntax EndAuthStep ::= "init"
  // -----------------------------
+    rule <k> End . _ => exception ... </k> [owise]
 
     syntax EndStep ::= "cage"
                      | "cage" Int

--- a/kmcd.md
+++ b/kmcd.md
@@ -64,7 +64,8 @@ End Semantics
     rule contract(End . _) => End
 
     syntax EndStep ::= EndAuthStep
- // ------------------------------
+    syntax AuthStep ::= EndAuthStep
+ // -------------------------------
 
     syntax EndAuthStep ::= "init"
  // -----------------------------

--- a/kmcd.md
+++ b/kmcd.md
@@ -63,6 +63,7 @@ End Semantics
     syntax MCDStep ::= EndContract "." EndStep [klabel(endStep)]
  // ------------------------------------------------------------
     rule contract(End . _) => End
+    rule [[ address(End) => ADDR ]] <end-addr> ADDR </end-addr>
 
     syntax EndStep ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]

--- a/kmcd.md
+++ b/kmcd.md
@@ -66,9 +66,6 @@ End Semantics
     syntax EndStep ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]
  // -----------------------------------------------------------------
-
-    syntax EndAuthStep ::= "init"
- // -----------------------------
     rule <k> End . _ => exception ... </k> [owise]
 
     syntax EndStep ::= "cage"

--- a/kmcd.md
+++ b/kmcd.md
@@ -59,13 +59,13 @@ End Semantics
 ```k
     syntax MCDContract ::= EndContract
     syntax EndContract ::= "End"
-    syntax MCDStep ::= EndContract "." EndStep
- // ------------------------------------------
+    syntax MCDStep ::= EndContract "." EndStep [klabel(endStep)]
+ // ------------------------------------------------------------
     rule contract(End . _) => End
 
     syntax EndStep ::= EndAuthStep
-    syntax AuthStep ::= EndAuthStep
- // -------------------------------
+    syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]
+ // -----------------------------------------------------------------
 
     syntax EndAuthStep ::= "init"
  // -----------------------------

--- a/kmcd.md
+++ b/kmcd.md
@@ -38,7 +38,6 @@ module KMCD
         <endPhase> false </endPhase>
         <endStack> .List </endStack>
         <end>
-          <end-ward> .Map </end-ward> // mapping (address => uint)                         Address |-> Bool
           <end-live> 0    </end-live>
           <end-when> 0    </end-when>
           <end-wait> 0    </end-wait>

--- a/kmcd.md
+++ b/kmcd.md
@@ -37,7 +37,6 @@ module KMCD
           <collateral/>
           <rates/>
           <endPhase> false </endPhase>
-          <endStack> .List </endStack>
           <end>
             <end-live> 0    </end-live>
             <end-when> 0    </end-when>

--- a/kmcd.md
+++ b/kmcd.md
@@ -30,25 +30,27 @@ module KMCD
     configuration
       <kmcd>
         <kmcd-driver/>
-        <cdp-core/>
-        <dai/>
-        <stabilize/>
-        <collateral/>
-        <rates/>
-        <endPhase> false </endPhase>
-        <endStack> .List </endStack>
-        <end>
-          <end-live> 0    </end-live>
-          <end-when> 0    </end-when>
-          <end-wait> 0    </end-wait>
-          <end-debt> 0    </end-debt>
-          <end-tag>  .Map </end-tag>  // mapping (bytes32 => uint256)                      Int     |-> Ray
-          <end-gap>  .Map </end-gap>  // mapping (bytes32 => uint256)                      Int     |-> Wad
-          <end-art>  .Map </end-art>  // mapping (bytes32 => uint256)                      Int     |-> Wad
-          <end-fix>  .Map </end-fix>  // mapping (bytes32 => uint256)                      Int     |-> Ray
-          <end-bag>  .Map </end-bag>  // mapping (address => uint256)                      Int     |-> Wad
-          <end-out>  .Map </end-out>  // mapping (bytes32 => mapping (address => uint256)) Int     |-> Wad
-        </end>
+        <kmcd-state>
+          <cdp-core/>
+          <dai/>
+          <stabilize/>
+          <collateral/>
+          <rates/>
+          <endPhase> false </endPhase>
+          <endStack> .List </endStack>
+          <end>
+            <end-live> 0    </end-live>
+            <end-when> 0    </end-when>
+            <end-wait> 0    </end-wait>
+            <end-debt> 0    </end-debt>
+            <end-tag>  .Map </end-tag>  // mapping (bytes32 => uint256)                      Int     |-> Ray
+            <end-gap>  .Map </end-gap>  // mapping (bytes32 => uint256)                      Int     |-> Wad
+            <end-art>  .Map </end-art>  // mapping (bytes32 => uint256)                      Int     |-> Wad
+            <end-fix>  .Map </end-fix>  // mapping (bytes32 => uint256)                      Int     |-> Ray
+            <end-bag>  .Map </end-bag>  // mapping (address => uint256)                      Int     |-> Wad
+            <end-out>  .Map </end-out>  // mapping (bytes32 => mapping (address => uint256)) Int     |-> Wad
+          </end>
+        </kmcd-state>
       </kmcd>
 ```
 

--- a/kmcd.md
+++ b/kmcd.md
@@ -57,8 +57,10 @@ End Semantics
 -------------
 
 ```k
-    syntax MCDStep ::= "End" "." EndStep
- // ------------------------------------
+    syntax MCDContract ::= EndContract
+    syntax EndContract ::= "End"
+    syntax MCDStep ::= EndContract "." EndStep
+ // ------------------------------------------
 
     syntax EndStep ::= EndAuthStep
  // ------------------------------

--- a/kmcd.md
+++ b/kmcd.md
@@ -67,8 +67,8 @@ End Semantics
  // -----------------------------------------------------------------
     rule <k> End . _ => exception ... </k> [owise]
 
-    syntax EndStep ::= "cage"
-                     | "cage" Int
+    syntax EndAuthStep ::= "cage"
+    syntax EndStep ::= "cage" Int
  // -----------------------------
 
     syntax EndStep ::= "skip" Int Int

--- a/kmcd.md
+++ b/kmcd.md
@@ -72,12 +72,6 @@ End Semantics
     syntax EndAuthStep ::= "init"
  // -----------------------------
 
-    syntax EndStep ::= StashStep
- // ----------------------------
-
-    syntax EndStep ::= ExceptionStep
- // --------------------------------
-
     syntax EndStep ::= "cage"
                      | "cage" Int
  // -----------------------------

--- a/kmcd.md
+++ b/kmcd.md
@@ -54,6 +54,22 @@ module KMCD
       </kmcd>
 ```
 
+State Storage/Revert Semantics
+------------------------------
+
+```k
+    rule <k> pushState => . ... </k>
+         <kmcd-state> STATE </kmcd-state>
+         <preState> _ => <kmcd-state> STATE </kmcd-state> </preState>
+
+    rule <k> dropState => . ... </k>
+         <preState> _ => .K </preState>
+
+    rule <k> popState => . ... </k>
+         (_:KmcdStateCell => <kmcd-state> STATE </kmcd-state>)
+         <preState> <kmcd-state> STATE </kmcd-state> </preState>
+```
+
 End Semantics
 -------------
 

--- a/rates.md
+++ b/rates.md
@@ -25,9 +25,6 @@ module RATES
 
     syntax MCDStep ::= "Pot" "." PotStep
  // ------------------------------------
-    rule <k> step [ Pot . PAS:PotAuthStep ] => Pot . push ~> Pot . auth ~> Pot . PAS ~> Pot . catch ... </k>
-    rule <k> step [ Pot . PS              ] => Pot . push ~>               Pot . PS  ~> Pot . catch ... </k>
-      requires notBool isPotAuthStep(PS)
 
     syntax PotStep ::= PotAuthStep
  // ------------------------------

--- a/rates.md
+++ b/rates.md
@@ -30,7 +30,8 @@ module RATES
     rule contract(Pot . _) => Pot
 
     syntax PotStep ::= PotAuthStep
- // ------------------------------
+    syntax AuthStep ::= PotAuthStep
+ // -------------------------------
 
     syntax PotAuthStep ::= "init" Address
  // -------------------------------------

--- a/rates.md
+++ b/rates.md
@@ -34,14 +34,6 @@ module RATES
  // -----------------------------------------------------------------
     rule <k> Pot . _ => exception ... </k> [owise]
 
-    syntax PotAuthStep ::= "init" Address
- // -------------------------------------
-    rule <k> Pot . init ILK => . ... </k>
-         <currentTime> TIME </currentTime>
-         <pot-dsr> _ => ilk_init </pot-dsr>
-         <pot-chi> _ => ilk_init </pot-chi>
-         <pot-rho> _ => TIME </pot-rho>
-
     syntax PotStep ::= "drip"
  // -------------------------
     rule <k> Pot . drip => Vat . suck VOW THIS ( CHI +Int (((#pow(DSR, TIME -Int RHO) *Int CHI) -Int CHI) ) ) ... </k>

--- a/rates.md
+++ b/rates.md
@@ -29,24 +29,6 @@ module RATES
     syntax PotStep ::= PotAuthStep
  // ------------------------------
 
-    syntax PotStep ::= AuthStep
- // ---------------------------
-    rule <k> Pot . auth => . ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <pot-ward> ... MSGSENDER |-> true ... </pot-ward>
-
-    rule <k> Pot . auth => Pot . exception ... </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <pot-ward> ... MSGSENDER |-> false ... </pot-ward>
-
-    syntax PotAuthStep ::= WardStep
- // -------------------------------
-    rule <k> Pot . rely ADDR => . ... </k>
-         <pot-ward> ... ADDR |-> (_ => true) ... </pot-ward>
-
-    rule <k> Pot . deny ADDR => . ... </k>
-         <pot-ward> ... ADDR |-> (_ => false) ... </pot-ward>
-
     syntax PotAuthStep ::= "init" Address
  // -------------------------------------
     rule <k> Pot . init ILK => . ... </k>

--- a/rates.md
+++ b/rates.md
@@ -11,7 +11,6 @@ module RATES
 
     configuration
       <rates>
-        <potStack> .List </potStack>
         <pot>
           <pot-pies> .Map      </pot-pies> // mapping (address => uint256) Address |-> Int
           <pot-pie>  0         </pot-pie>

--- a/rates.md
+++ b/rates.md
@@ -25,13 +25,13 @@ module RATES
 
     syntax MCDContract ::= PotContract
     syntax PotContract ::= "Pot"
-    syntax MCDStep ::= PotContract "." PotStep
- // ------------------------------------------
+    syntax MCDStep ::= PotContract "." PotStep [klabel(potStep)]
+ // ------------------------------------------------------------
     rule contract(Pot . _) => Pot
 
     syntax PotStep ::= PotAuthStep
-    syntax AuthStep ::= PotAuthStep
- // -------------------------------
+    syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]
+ // -----------------------------------------------------------------
 
     syntax PotAuthStep ::= "init" Address
  // -------------------------------------

--- a/rates.md
+++ b/rates.md
@@ -29,26 +29,6 @@ module RATES
     syntax PotStep ::= PotAuthStep
  // ------------------------------
 
-    syntax PotStep ::= StashStep
- // ----------------------------
-    rule <k> Pot . push => . ... </k>
-         <potStack> (.List => ListItem(POT)) ... </potStack>
-         <pot> POT </pot>
-
-    rule <k> Pot . pop => . ... </k>
-         <potStack> (ListItem(POT) => .List) ... </potStack>
-         <pot> _ => POT </pot>
-
-    rule <k> Pot . drop => . ... </k>
-         <potStack> (ListItem(_) => .List) ... </potStack>
-
-    syntax PotStep ::= ExceptionStep
- // --------------------------------
-    rule <k>                     Pot . catch => Pot . drop ... </k>
-    rule <k> Pot . exception ~>  Pot . catch => Pot . pop  ... </k>
-    rule <k> Pot . exception ~> (Pot . PS    => .)         ... </k>
-      requires PS =/=K catch
-
     syntax PotStep ::= AuthStep
  // ---------------------------
     rule <k> Pot . auth => . ... </k>

--- a/rates.md
+++ b/rates.md
@@ -23,8 +23,10 @@ module RATES
         </pot>
       </rates>
 
-    syntax MCDStep ::= "Pot" "." PotStep
- // ------------------------------------
+    syntax MCDContract ::= PotContract
+    syntax PotContract ::= "Pot"
+    syntax MCDStep ::= PotContract "." PotStep
+ // ------------------------------------------
 
     syntax PotStep ::= PotAuthStep
  // ------------------------------

--- a/rates.md
+++ b/rates.md
@@ -12,6 +12,7 @@ module RATES
     configuration
       <rates>
         <pot>
+          <pot-addr> 0:Address </pot-addr>
           <pot-pies> .Map      </pot-pies> // mapping (address => uint256) Address |-> Int
           <pot-pie>  0         </pot-pie>
           <pot-dsr>  0         </pot-dsr>

--- a/rates.md
+++ b/rates.md
@@ -27,6 +27,7 @@ module RATES
     syntax PotContract ::= "Pot"
     syntax MCDStep ::= PotContract "." PotStep
  // ------------------------------------------
+    rule contract(Pot . _) => Pot
 
     syntax PotStep ::= PotAuthStep
  // ------------------------------

--- a/rates.md
+++ b/rates.md
@@ -36,7 +36,7 @@ module RATES
 
     syntax PotStep ::= "drip"
  // -------------------------
-    rule <k> Pot . drip => Vat . suck VOW THIS ( CHI +Int (((#pow(DSR, TIME -Int RHO) *Int CHI) -Int CHI) ) ) ... </k>
+    rule <k> Pot . drip => call Vat . suck VOW THIS ( CHI +Int (((#pow(DSR, TIME -Int RHO) *Int CHI) -Int CHI) ) ) ... </k>
          <this> THIS </this>
          <currentTime> TIME </currentTime>
          <pot-chi> CHI => CHI +Int (((#pow(DSR, TIME -Int RHO) *Int CHI) -Int CHI) ) </pot-chi>

--- a/rates.md
+++ b/rates.md
@@ -27,6 +27,7 @@ module RATES
     syntax MCDStep ::= PotContract "." PotStep [klabel(potStep)]
  // ------------------------------------------------------------
     rule contract(Pot . _) => Pot
+    rule [[ address(Pot) => ADDR ]] <pot-addr> ADDR </pot-addr>
 
     syntax PotStep ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]

--- a/rates.md
+++ b/rates.md
@@ -50,5 +50,8 @@ module RATES
     syntax PotStep ::= "exit" Wad
  // -----------------------------
 
+    syntax PotAuthStep ::= "cage"
+ // -----------------------------
+
 endmodule
 ```

--- a/rates.md
+++ b/rates.md
@@ -41,8 +41,6 @@ module RATES
          <pot-chi> _ => ilk_init </pot-chi>
          <pot-rho> _ => TIME </pot-rho>
 
-    rule <k> Pot . init _ => Pot . exception ... </k> [owise]
-
     syntax PotStep ::= "drip"
  // -------------------------
     rule <k> Pot . drip => Vat . suck VOW THIS ( CHI +Int (((#pow(DSR, TIME -Int RHO) *Int CHI) -Int CHI) ) ) ... </k>

--- a/rates.md
+++ b/rates.md
@@ -32,6 +32,7 @@ module RATES
     syntax PotStep ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]
  // -----------------------------------------------------------------
+    rule <k> Pot . _ => exception ... </k> [owise]
 
     syntax PotAuthStep ::= "init" Address
  // -------------------------------------

--- a/rates.md
+++ b/rates.md
@@ -13,7 +13,6 @@ module RATES
       <rates>
         <potStack> .List </potStack>
         <pot>
-          <pot-ward> .Map      </pot-ward> // mapping (address => uint)    Address |-> Bool
           <pot-pies> .Map      </pot-pies> // mapping (address => uint256) Address |-> Int
           <pot-pie>  0         </pot-pie>
           <pot-dsr>  0         </pot-dsr>

--- a/stabilize.md
+++ b/stabilize.md
@@ -54,6 +54,7 @@ Flap Semantics
     rule contract(Flap . _) => Flap
 
     syntax FlapStep ::= FlapAuthStep
+    syntax AuthStep ::= FlapAuthStep
  // --------------------------------
 
     syntax FlapAuthStep ::= "init" Address Address
@@ -86,6 +87,7 @@ Flop Semantics
     rule contract(Flop . _) => Flop
 
     syntax FlopStep ::= FlopAuthStep
+    syntax AuthStep ::= FlopAuthStep
  // --------------------------------
 
     syntax FlopAuthStep ::= "init" Address Address
@@ -121,7 +123,8 @@ Vow Semantics
     rule contract(Vow . _) => Vow
 
     syntax VowStep ::= VowAuthStep
- // ------------------------------
+    syntax AuthStep ::= VowAuthStep
+ // -------------------------------
 
     syntax VowAuthStep ::= "init" Address Address Address
  // -----------------------------------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -13,21 +13,18 @@ module SYSTEM-STABILIZER
       <stabilize>
         <flapStack> .List </flapStack>
         <flapState>
-          <flap-ward> .Map </flap-ward>  // mapping (address => uint) Address |-> Bool
           <flap-bids> .Map </flap-bids>  // mapping (uint => Bid)     Int     |-> Bid
           <flap-kicks> 0   </flap-kicks>
           <flap-live>  0   </flap-live>
         </flapState>
         <flopStack> .List </flopStack>
         <flopState>
-          <flop-ward> .Map </flop-ward>  // mapping (address => uint) Address |-> Bool
           <flop-bids> .Map </flop-bids>  // mapping (uint => Bid)     Int     |-> Bid
           <flop-kicks> 0   </flop-kicks>
           <flop-live>  0   </flop-live>
         </flopState>
         <vowStack> .List </vowStack>
         <vow>
-          <vow-ward>  .Map </vow-ward> // mapping (address => uint)    Address |-> Bool
           <vow-sins>  .Map </vow-sins> // mapping (uint256 => uint256) Int     |-> Int
           <vow-sin>   0    </vow-sin>
           <vow-ash>   0    </vow-ash>

--- a/stabilize.md
+++ b/stabilize.md
@@ -49,6 +49,7 @@ Flap Semantics
     syntax MCDStep ::= FlapContract "." FlapStep [klabel(flapStep)]
  // ---------------------------------------------------------------
     rule contract(Flap . _) => Flap
+    rule [[ address(Flap) => ADDR ]] <flap-addr> ADDR </flap-addr>
 
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]
@@ -80,6 +81,7 @@ Flop Semantics
     syntax MCDStep ::= FlopContract "." FlopStep [klabel(flopStep)]
  // ---------------------------------------------------------------
     rule contract(Flop . _) => Flop
+    rule [[ address(Flop) => ADDR ]] <flop-addr> ADDR </flop-addr>
 
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
@@ -114,6 +116,7 @@ Vow Semantics
     syntax MCDStep ::= VowContract "." VowStep [klabel(vowStep)]
  // ------------------------------------------------------------
     rule contract(Vow . _) => Vow
+    rule [[ address(Vow) => ADDR ]] <vow-addr> ADDR </vow-addr>
 
     syntax VowStep ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]

--- a/stabilize.md
+++ b/stabilize.md
@@ -53,12 +53,6 @@ Flap Semantics
     syntax FlapStep ::= FlapAuthStep
  // --------------------------------
 
-    syntax FlapAuthStep ::= AuthStep
- // --------------------------------
-
-    syntax FlapAuthStep ::= WardStep
- // --------------------------------
-
     syntax FlapAuthStep ::= "init" Address Address
  // ----------------------------------------------
 
@@ -86,12 +80,6 @@ Flop Semantics
  // --------------------------------------
 
     syntax FlopStep ::= FlopAuthStep
- // --------------------------------
-
-    syntax FlopAuthStep ::= AuthStep
- // --------------------------------
-
-    syntax FlopAuthStep ::= WardStep
  // --------------------------------
 
     syntax FlopAuthStep ::= "init" Address Address
@@ -125,12 +113,6 @@ Vow Semantics
 
     syntax VowStep ::= VowAuthStep
  // ------------------------------
-
-    syntax VowAuthStep ::= AuthStep
- // -------------------------------
-
-    syntax VowAuthStep ::= WardStep
- // -------------------------------
 
     syntax VowAuthStep ::= "init" Address Address Address
  // -----------------------------------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -11,19 +11,16 @@ module SYSTEM-STABILIZER
 
     configuration
       <stabilize>
-        <flapStack> .List </flapStack>
         <flapState>
           <flap-bids> .Map </flap-bids>  // mapping (uint => Bid)     Int     |-> Bid
           <flap-kicks> 0   </flap-kicks>
           <flap-live>  0   </flap-live>
         </flapState>
-        <flopStack> .List </flopStack>
         <flopState>
           <flop-bids> .Map </flop-bids>  // mapping (uint => Bid)     Int     |-> Bid
           <flop-kicks> 0   </flop-kicks>
           <flop-live>  0   </flop-live>
         </flopState>
-        <vowStack> .List </vowStack>
         <vow>
           <vow-sins>  .Map </vow-sins> // mapping (uint256 => uint256) Int     |-> Int
           <vow-sin>   0    </vow-sin>

--- a/stabilize.md
+++ b/stabilize.md
@@ -47,8 +47,10 @@ Flap Semantics
     syntax Bid ::= Bid ( Int, Int, Address, Int, Int ) [klabel(BidBid)]
  // -------------------------------------------------------------------
 
-    syntax MCDStep ::= "Flap" "." FlapStep
- // --------------------------------------
+    syntax MCDContract ::= FlapContract
+    syntax FlapContract ::= "Flap"
+    syntax MCDStep ::= FlapContract "." FlapStep
+ // --------------------------------------------
 
     syntax FlapStep ::= FlapAuthStep
  // --------------------------------
@@ -76,8 +78,10 @@ Flop Semantics
 --------------
 
 ```k
-    syntax MCDStep ::= "Flop" "." FlopStep
- // --------------------------------------
+    syntax MCDContract ::= FlopContract
+    syntax FlopContract ::= "Flop"
+    syntax MCDStep ::= FlopContract "." FlopStep
+ // --------------------------------------------
 
     syntax FlopStep ::= FlopAuthStep
  // --------------------------------
@@ -108,8 +112,10 @@ Vow Semantics
 -------------
 
 ```k
-    syntax MCDStep ::= "Vow" "." VowStep
- // ------------------------------------
+    syntax MCDContract ::= VowContract
+    syntax VowContract ::= "Vow"
+    syntax MCDStep ::= VowContract "." VowStep
+ // ------------------------------------------
 
     syntax VowStep ::= VowAuthStep
  // ------------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -62,12 +62,6 @@ Flap Semantics
     syntax FlapAuthStep ::= "init" Address Address
  // ----------------------------------------------
 
-    syntax FlapStep ::= StashStep
- // -----------------------------
-
-    syntax FlapStep ::= ExceptionStep
- // ---------------------------------
-
     syntax FlapStep ::= "kick" Int Int
  // ----------------------------------
 
@@ -102,12 +96,6 @@ Flop Semantics
 
     syntax FlopAuthStep ::= "init" Address Address
  // ----------------------------------------------
-
-    syntax FlopStep ::= StashStep
- // -----------------------------
-
-    syntax FlopStep ::= ExceptionStep
- // ---------------------------------
 
     syntax FlopStep ::= "kick" Int Int Int
  // --------------------------------------
@@ -146,12 +134,6 @@ Vow Semantics
 
     syntax VowAuthStep ::= "init" Address Address Address
  // -----------------------------------------------------
-
-    syntax VowStep ::= StashStep
- // ----------------------------
-
-    syntax VowStep ::= ExceptionStep
- // --------------------------------
 
     syntax VowStep ::= "fess" Int
  // -----------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -51,6 +51,7 @@ Flap Semantics
     syntax FlapContract ::= "Flap"
     syntax MCDStep ::= FlapContract "." FlapStep
  // --------------------------------------------
+    rule contract(Flap . _) => Flap
 
     syntax FlapStep ::= FlapAuthStep
  // --------------------------------
@@ -82,6 +83,7 @@ Flop Semantics
     syntax FlopContract ::= "Flop"
     syntax MCDStep ::= FlopContract "." FlopStep
  // --------------------------------------------
+    rule contract(Flop . _) => Flop
 
     syntax FlopStep ::= FlopAuthStep
  // --------------------------------
@@ -116,6 +118,7 @@ Vow Semantics
     syntax VowContract ::= "Vow"
     syntax MCDStep ::= VowContract "." VowStep
  // ------------------------------------------
+    rule contract(Vow . _) => Vow
 
     syntax VowStep ::= VowAuthStep
  // ------------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -64,8 +64,8 @@ Flap Semantics
     syntax FlapStep ::= "deal" Int
  // ------------------------------
 
-    syntax FlapStep ::= "cage" Int
- // ------------------------------
+    syntax FlapAuthStep ::= "cage" Int
+ // ----------------------------------
 
     syntax FlapStep ::= "yank" Int
  // ------------------------------
@@ -86,8 +86,8 @@ Flop Semantics
  // --------------------------------------------------------------------
     rule <k> Flop . _ => exception ... </k> [owise]
 
-    syntax FlopStep ::= "kick" Int Int Int
- // --------------------------------------
+    syntax FlopAuthStep ::= "kick" Int Int Int
+ // ------------------------------------------
 
     syntax FlopStep ::= "tick" Int
  // ------------------------------
@@ -98,8 +98,8 @@ Flop Semantics
     syntax FlopStep ::= "deal" Int
  // ------------------------------
 
-    syntax FlopStep ::= "cage"
- // --------------------------
+    syntax FlopAuthStep ::= "cage"
+ // ------------------------------
 
     syntax FlopStep ::= "yank" Int
  // ------------------------------
@@ -120,8 +120,8 @@ Vow Semantics
  // -----------------------------------------------------------------
     rule <k> Vow . _ => exception ... </k> [owise]
 
-    syntax VowStep ::= "fess" Int
- // -----------------------------
+    syntax VowAuthStep ::= "fess" Int
+ // ---------------------------------
 
     syntax VowStep ::= "flog" Int
  // -----------------------------
@@ -138,8 +138,8 @@ Vow Semantics
     syntax VowStep ::= "flap"
  // -------------------------
 
-    syntax VowStep ::= "cage"
- // -------------------------
+    syntax VowAuthStep ::= "cage"
+ // -----------------------------
 
 ```
 

--- a/stabilize.md
+++ b/stabilize.md
@@ -12,24 +12,27 @@ module SYSTEM-STABILIZER
     configuration
       <stabilize>
         <flapState>
-          <flap-bids> .Map </flap-bids>  // mapping (uint => Bid)     Int     |-> Bid
-          <flap-kicks> 0   </flap-kicks>
-          <flap-live>  0   </flap-live>
+          <flap-addr>  0:Address </flap-addr>
+          <flap-bids>  .Map      </flap-bids>  // mapping (uint => Bid)     Int     |-> Bid
+          <flap-kicks> 0         </flap-kicks>
+          <flap-live>  0         </flap-live>
         </flapState>
         <flopState>
-          <flop-bids> .Map </flop-bids>  // mapping (uint => Bid)     Int     |-> Bid
-          <flop-kicks> 0   </flop-kicks>
-          <flop-live>  0   </flop-live>
+          <flop-addr>  0:Address </flop-addr>
+          <flop-bids>  .Map      </flop-bids>  // mapping (uint => Bid)     Int     |-> Bid
+          <flop-kicks> 0         </flop-kicks>
+          <flop-live>  0         </flop-live>
         </flopState>
         <vow>
-          <vow-sins>  .Map </vow-sins> // mapping (uint256 => uint256) Int     |-> Int
-          <vow-sin>   0    </vow-sin>
-          <vow-ash>   0    </vow-ash>
-          <vow-wait>  0    </vow-wait>
-          <vow-sump>  0    </vow-sump>
-          <vow-bump>  0    </vow-bump>
-          <vow-hump>  0    </vow-hump>
-          <vow-live>  0    </vow-live>
+          <vow-addr> 0:Address </vow-addr>
+          <vow-sins> .Map      </vow-sins> // mapping (uint256 => uint256) Int     |-> Int
+          <vow-sin>  0         </vow-sin>
+          <vow-ash>  0         </vow-ash>
+          <vow-wait> 0         </vow-wait>
+          <vow-sump> 0         </vow-sump>
+          <vow-bump> 0         </vow-bump>
+          <vow-hump> 0         </vow-hump>
+          <vow-live> 0         </vow-live>
         </vow>
       </stabilize>
 ```

--- a/stabilize.md
+++ b/stabilize.md
@@ -56,9 +56,6 @@ Flap Semantics
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]
  // --------------------------------------------------------------------
-
-    syntax FlapAuthStep ::= "init" Address Address
- // ----------------------------------------------
     rule <k> Flap . _ => exception ... </k> [owise]
 
     syntax FlapStep ::= "kick" Int Int
@@ -91,9 +88,6 @@ Flop Semantics
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
  // --------------------------------------------------------------------
     rule <k> Flop . _ => exception ... </k> [owise]
-
-    syntax FlopAuthStep ::= "init" Address Address
- // ----------------------------------------------
 
     syntax FlopStep ::= "kick" Int Int Int
  // --------------------------------------
@@ -128,9 +122,6 @@ Vow Semantics
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]
  // -----------------------------------------------------------------
     rule <k> Vow . _ => exception ... </k> [owise]
-
-    syntax VowAuthStep ::= "init" Address Address Address
- // -----------------------------------------------------
 
     syntax VowStep ::= "fess" Int
  // -----------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -49,13 +49,13 @@ Flap Semantics
 
     syntax MCDContract ::= FlapContract
     syntax FlapContract ::= "Flap"
-    syntax MCDStep ::= FlapContract "." FlapStep
- // --------------------------------------------
+    syntax MCDStep ::= FlapContract "." FlapStep [klabel(flapStep)]
+ // ---------------------------------------------------------------
     rule contract(Flap . _) => Flap
 
     syntax FlapStep ::= FlapAuthStep
-    syntax AuthStep ::= FlapAuthStep
- // --------------------------------
+    syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]
+ // --------------------------------------------------------------------
 
     syntax FlapAuthStep ::= "init" Address Address
  // ----------------------------------------------
@@ -82,13 +82,13 @@ Flop Semantics
 ```k
     syntax MCDContract ::= FlopContract
     syntax FlopContract ::= "Flop"
-    syntax MCDStep ::= FlopContract "." FlopStep
- // --------------------------------------------
+    syntax MCDStep ::= FlopContract "." FlopStep [klabel(flopStep)]
+ // ---------------------------------------------------------------
     rule contract(Flop . _) => Flop
 
     syntax FlopStep ::= FlopAuthStep
-    syntax AuthStep ::= FlopAuthStep
- // --------------------------------
+    syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
+ // --------------------------------------------------------------------
 
     syntax FlopAuthStep ::= "init" Address Address
  // ----------------------------------------------
@@ -118,13 +118,13 @@ Vow Semantics
 ```k
     syntax MCDContract ::= VowContract
     syntax VowContract ::= "Vow"
-    syntax MCDStep ::= VowContract "." VowStep
- // ------------------------------------------
+    syntax MCDStep ::= VowContract "." VowStep [klabel(vowStep)]
+ // ------------------------------------------------------------
     rule contract(Vow . _) => Vow
 
     syntax VowStep ::= VowAuthStep
-    syntax AuthStep ::= VowAuthStep
- // -------------------------------
+    syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]
+ // -----------------------------------------------------------------
 
     syntax VowAuthStep ::= "init" Address Address Address
  // -----------------------------------------------------

--- a/stabilize.md
+++ b/stabilize.md
@@ -59,6 +59,7 @@ Flap Semantics
 
     syntax FlapAuthStep ::= "init" Address Address
  // ----------------------------------------------
+    rule <k> Flap . _ => exception ... </k> [owise]
 
     syntax FlapStep ::= "kick" Int Int
  // ----------------------------------
@@ -89,6 +90,7 @@ Flop Semantics
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
  // --------------------------------------------------------------------
+    rule <k> Flop . _ => exception ... </k> [owise]
 
     syntax FlopAuthStep ::= "init" Address Address
  // ----------------------------------------------
@@ -125,6 +127,7 @@ Vow Semantics
     syntax VowStep ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]
  // -----------------------------------------------------------------
+    rule <k> Vow . _ => exception ... </k> [owise]
 
     syntax VowAuthStep ::= "init" Address Address Address
  // -----------------------------------------------------


### PR DESCRIPTION
This PR will not be merged as I am making it pointing into the vat branch so as to clearly show the changes despite the fact that the vat refactoring isn't done yet. I am simply making it so that people can take a look at the high level changes I made and discuss and make suggestions without blocking us on the low level details of the two PRs this depends on.

What this does at a high level:
* moves logic relating to exceptions, state reverts, and authentiation entirely into kmcd-river.md.
* fixes various low level issues involving authorization in various steps
* unifies the negative cases into fewer rules
* cleans up some stuff relating to incorrect "init" functions
* cleans up the configuration
* adds logic for function calls