### PR TITLE
Note modifier

### DIFF
--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -61,7 +61,7 @@ Function Calls
          <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(MCD)) </this>
          <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
-         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, AS)) </frame-events>
+         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires notBool isAuthStep(MCD)
 
     syntax ReturnValue ::= Int | Rat

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -45,7 +45,7 @@ Function Calls
 --------------
 
 ```k
-    syntax CallFrame ::= frame(prevSender: Address, prevEvents: List, ntinuation: K)
+    syntax CallFrame ::= frame(prevSender: Address, prevEvents: List, continuation: K)
 
     syntax AuthStep
     syntax MCDStep ::= AuthStep

--- a/vat.md
+++ b/vat.md
@@ -161,7 +161,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . nope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS -Set SetItem(ADDRTO)) ... </vat-can>
-	 <frame-events> _ => .List </frame-events>
+         <frame-events> _ => .List </frame-events>
 ```
 
 -   `Vat.safe` checks that a given `Urn` of a certain `ilk` is not over-leveraged.

--- a/vat.md
+++ b/vat.md
@@ -156,7 +156,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . hope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS SetItem(ADDRTO)) ... </vat-can>
-	 <frame-events> _ => .List </frame-events>
+         <frame-events> _ => .List </frame-events>
 
     rule <k> Vat . nope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>

--- a/vat.md
+++ b/vat.md
@@ -156,10 +156,12 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . hope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS SetItem(ADDRTO)) ... </vat-can>
+	 <frame-events> _ => .List </frame-events>
 
     rule <k> Vat . nope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS -Set SetItem(ADDRTO)) ... </vat-can>
+	 <frame-events> _ => .List </frame-events>
 ```
 
 -   `Vat.safe` checks that a given `Urn` of a certain `ilk` is not over-leveraged.

--- a/vat.md
+++ b/vat.md
@@ -156,12 +156,10 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . hope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS SetItem(ADDRTO)) ... </vat-can>
-         <frame-events> _ => .List </frame-events>
 
     rule <k> Vat . nope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS -Set SetItem(ADDRTO)) ... </vat-can>
-         <frame-events> _ => .List </frame-events>
 ```
 
 -   `Vat.safe` checks that a given `Urn` of a certain `ilk` is not over-leveraged.


### PR DESCRIPTION
This code essentially assumes that any method that doesn't have the note modifier will explicitly rewrite the `frame-events` cell to the exact events emitted by that call frame.