### PR TITLE
Transact corrections, udpates to build harness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     stage('Dependencies') {
       steps {
         sh '''
-          make deps
+          make deps K_BUILD_TYPE=Release
         '''
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ MAIN_MODULE    := KMCD
 SYNTAX_MODULE  := $(MAIN_MODULE)
 MAIN_DEFN_FILE := kmcd
 
-KOMPILE_OPTS      ?= --emit-json
+KOMPILE_OPTS      :=
 LLVM_KOMPILE_OPTS := $(KOMPILE_OPTS) -ccopt -O2
 
 k_files := $(MAIN_DEFN_FILE).k kmcd.k kmcd-driver.k cat.k dai.k end.k flap.k flip.k flop.k gem.k join.k jug.k pot.k spot.k vat.k vow.k
@@ -117,6 +117,7 @@ $(llvm_kompiled): $(llvm_files)
 	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend llvm              \
 	                 --syntax-module $(SYNTAX_MODULE) $(llvm_dir)/$(MAIN_DEFN_FILE).k \
 	                 --directory $(llvm_dir) -I $(llvm_dir)                           \
+	                 --emit-json                                                      \
 	                 $(LLVM_KOMPILE_OPTS)
 
 # Haskell Backend
@@ -124,14 +125,18 @@ $(llvm_kompiled): $(llvm_files)
 $(haskell_kompiled): $(haskell_files)
 	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend haskell              \
 	                 --syntax-module $(SYNTAX_MODULE) $(haskell_dir)/$(MAIN_DEFN_FILE).k \
-	                 --directory $(haskell_dir) -I $(haskell_dir)
+	                 --directory $(haskell_dir) -I $(haskell_dir)                        \
+	                 --emit-json                                                         \
+	                 $(KOMPILE_OPTS)
 
 # Java Backend
 
 $(java_kompiled): $(java_files)
 	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend java              \
 	                 --syntax-module $(SYNTAX_MODULE) $(java_dir)/$(MAIN_DEFN_FILE).k \
-	                 --directory $(java_dir) -I $(java_dir)
+	                 --directory $(java_dir) -I $(java_dir)							  \
+	                 --emit-json                                                      \
+	                 $(KOMPILE_OPTS)
 
 # Test
 # ----

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ K_BIN     := $(K_RELEASE)/bin
 K_LIB     := $(K_RELEASE)/lib
 export K_RELEASE
 
+K_BUILD_TYPE := Debug
+
 PATH:=$(K_BIN):$(PATH)
 export PATH
 
@@ -60,7 +62,7 @@ deps-tangle: $(PANDOC_TANGLE_SUBMODULE)/submodule.timestamp
 	touch $@
 
 $(K_SUBMODULE)/mvn.timestamp: $(K_SUBMODULE)/submodule.timestamp
-	cd $(K_SUBMODULE) && mvn package -DskipTests
+	cd $(K_SUBMODULE) && mvn package -DskipTests -Dproject.build.type=$(K_BUILD_TYPE)
 	touch $(K_SUBMODULE)/mvn.timestamp
 
 # Building

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ $(haskell_kompiled): $(haskell_files)
 	                 --directory $(haskell_dir) -I $(haskell_dir)                        \
 	                 --emit-json                                                         \
 	                 $(KOMPILE_OPTS)
+	./strip-erroneous-labels.sh $(haskell_kompiled)
 
 # Java Backend
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ K_BIN     := $(K_RELEASE)/bin
 K_LIB     := $(K_RELEASE)/lib
 export K_RELEASE
 
-K_BUILD_TYPE := Debug
+K_BUILD_TYPE := FastBuild
 
 PATH:=$(K_BIN):$(PATH)
 export PATH

--- a/cat.md
+++ b/cat.md
@@ -43,7 +43,6 @@ Cat Semantics
     syntax CatStep ::= CatAuthStep
     syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]
  // -----------------------------------------------------------------
-    rule <k> Cat . _ => exception ... </k> [owise]
 
     syntax CatStep ::= "bite" String Address
  // ----------------------------------------

--- a/dai.md
+++ b/dai.md
@@ -36,7 +36,6 @@ module DAI
     syntax DaiStep ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]
  // -----------------------------------------------------------------
-    rule <k> Dai . _ => exception ... </k> [owise]
 
     syntax Event ::= Transfer(Address, Address, Wad)
                    | Approval(Address, Address, Wad)

--- a/end.md
+++ b/end.md
@@ -54,7 +54,6 @@ End Semantics
     syntax EndStep ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]
  // -----------------------------------------------------------------
-    rule <k> End . _ => exception ... </k> [owise]
 
     syntax EndAuthStep ::= "cage"
  // -----------------------------

--- a/flap.md
+++ b/flap.md
@@ -44,7 +44,6 @@ Flap Semantics
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]
  // --------------------------------------------------------------------
-    rule <k> Flap . _ => exception ... </k> [owise]
 
     syntax Event ::= FlapKick(Int, Rad, Wad)
  // ----------------------------------------

--- a/flip.md
+++ b/flip.md
@@ -44,7 +44,6 @@ Flip Semantics
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]
  // --------------------------------------------------------------------
-    rule <k> Flip _ . _ => exception ... </k> [owise]
 
     syntax Event ::= FlipKick(Int, Wad, Rad, Rad, Address, Address)
  // ---------------------------------------------------------------

--- a/flop.md
+++ b/flop.md
@@ -45,7 +45,6 @@ Flop Semantics
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
  // --------------------------------------------------------------------
-    rule <k> Flop . _ => exception ... </k> [owise]
 
     syntax Event ::= FlopKick(Int, Wad, Rad, Address)
  // -------------------------------------------------

--- a/gem.md
+++ b/gem.md
@@ -34,7 +34,6 @@ Gem Semantics
     syntax GemStep ::= GemAuthStep
     syntax AuthStep ::= GemContract "." GemAuthStep [klabel(gemStep)]
  // -----------------------------------------------------------------
-    rule <k> Gem _ . _ => exception ... </k> [owise]
 
     syntax GemStep ::= "transferFrom" Address Address Wad
  // -----------------------------------------------------

--- a/join.md
+++ b/join.md
@@ -37,7 +37,6 @@ Join Semantics
  // ------------------------------------------------------------------------
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
     rule [[ address(GemJoin GEMID) => ACCTJOIN ]] <gemJoin-gem> GEMID </gemJoin-gem> <gemJoin-addr> ACCTJOIN </gemJoin-addr>
-    rule <k> GemJoin _ . _ => exception ... </k> [owise]
 
     syntax GemJoinStep ::= "join" Address Wad
  // -----------------------------------------
@@ -62,7 +61,6 @@ Join Semantics
  // ------------------------------------------------------------------------
     rule contract(DaiJoin . _) => DaiJoin
     rule [[ address(DaiJoin) => ACCTJOIN ]] <daiJoin-addr> ACCTJOIN </daiJoin-addr>
-    rule <k> DaiJoin . _ => exception ... </k> [owise]
 
     syntax DaiJoinStep ::= "join" Address Wad
  // -----------------------------------------

--- a/jug.md
+++ b/jug.md
@@ -41,7 +41,6 @@ Jug Semantics
     syntax JugStep ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]
  // -----------------------------------------------------------------
-    rule <k> Jug . _ => exception ... </k> [owise]
 
     syntax JugAuthStep ::= InitStep
  // -------------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -82,15 +82,18 @@ Function Calls
          <this> _ => ADDR </this>
          <msg-sender> _ => ADDR </msg-sender>
 
-    syntax MCDStep ::= "exception"
- // ------------------------------
-    rule <k> exception ~> _ => exception ~> CONT </k>
+    syntax MCDStep ::= MCDExceptionStep
+    syntax MCDExceptionStep ::= "exception" MCDStep
+ // -----------------------------------------------
+    rule <k> MCDSTEP:MCDStep => exception MCDSTEP ... </k> requires notBool isMCDExceptionStep(MCDSTEP) [owise]
+
+    rule <k> exception E ~> _ => exception E ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
          <this> THIS => MSGSENDER </this>
          <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ...</callStack>
          <frame-events> _ => PREVEVENTS </frame-events>
 
-    rule <k> exception ~> dropState => popState ... </k>
+    rule <k> exception _ ~> dropState => popState ... </k>
          <callStack> .List </callStack>
 
     syntax MCStep ::= "pushState" | "dropState" | "popState"

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -80,9 +80,11 @@ Function Calls
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
-    syntax MCDStep ::= "transact" MCDStep
- // -------------------------------------
-    rule <k> transact MCD:MCDStep => pushState ~> call MCD ~> dropState ... </k>
+    syntax MCDStep ::= "transact" Address MCDStep
+ // ---------------------------------------------
+    rule <k> transact ADDR:Address MCD:MCDStep => pushState ~> call MCD ~> dropState ... </k>
+         <this> _ => ADDR </this>
+         <msg-sender> _ => ADDR </msg-sender>
 
     syntax MCDStep ::= "exception"
  // ------------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -52,31 +52,27 @@ Function Calls
     syntax MCDStep ::= "call" MCDStep
  // ---------------------------------
     rule <k> call AS:AuthStep ~> CONT => contract(AS) . auth ~> AS </k>
-         <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(AS)) </this>
-         <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
-         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, AS)) </frame-events>
+         <callStack> .List => ListItem(frame(THIS, EVENTS, CONT)) ... </callStack>
+         <frame-events> EVENTS => ListItem(LogNote(THIS, AS)) </frame-events>
 
     rule <k> call MCD:MCDStep ~> CONT => MCD </k>
-         <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(MCD)) </this>
-         <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
-         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
+         <callStack> .List => ListItem(frame(THIS, EVENTS, CONT)) ... </callStack>
+         <frame-events> EVENTS => ListItem(LogNote(THIS, MCD)) </frame-events>
       requires notBool isAuthStep(MCD)
 
     syntax ReturnValue ::= Int | Rat
  // --------------------------------
     rule <k> R:ReturnValue => R ~> CONT </k>
-         <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
-         <this> THIS => MSGSENDER </this>
-         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </callStack>
+         <this> THIS => PREVCALLER </this>
+         <callStack> ListItem(frame(PREVCALLER, PREVEVENTS, CONT)) => .List ... </callStack>
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
     rule <k> . => CONT </k>
-         <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
-         <this> THIS => MSGSENDER </this>
-         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </callStack>
+         <this> THIS => PREVCALLER </this>
+         <callStack> ListItem(frame(PREVCALLER, PREVEVENTS, CONT)) => .List ... </callStack>
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -52,27 +52,31 @@ Function Calls
     syntax MCDStep ::= "call" MCDStep
  // ---------------------------------
     rule <k> call AS:AuthStep ~> CONT => contract(AS) . auth ~> AS </k>
+         <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(AS)) </this>
-         <callStack> .List => ListItem(frame(THIS, EVENTS, CONT)) ... </callStack>
-         <frame-events> EVENTS => ListItem(LogNote(THIS, AS)) </frame-events>
+         <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
+         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, AS)) </frame-events>
 
     rule <k> call MCD:MCDStep ~> CONT => MCD </k>
+         <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(MCD)) </this>
-         <callStack> .List => ListItem(frame(THIS, EVENTS, CONT)) ... </callStack>
-         <frame-events> EVENTS => ListItem(LogNote(THIS, MCD)) </frame-events>
+         <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
+         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires notBool isAuthStep(MCD)
 
     syntax ReturnValue ::= Int | Rat
  // --------------------------------
     rule <k> R:ReturnValue => R ~> CONT </k>
-         <this> THIS => PREVCALLER </this>
-         <callStack> ListItem(frame(PREVCALLER, PREVEVENTS, CONT)) => .List ... </callStack>
+         <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
+         <this> THIS => MSGSENDER </this>
+         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </callStack>
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
     rule <k> . => CONT </k>
-         <this> THIS => PREVCALLER </this>
-         <callStack> ListItem(frame(PREVCALLER, PREVEVENTS, CONT)) => .List ... </callStack>
+         <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
+         <this> THIS => MSGSENDER </this>
+         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </callStack>
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 

--- a/pot.md
+++ b/pot.md
@@ -38,7 +38,6 @@ Pot Semantics
     syntax PotStep ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]
  // -----------------------------------------------------------------
-    rule <k> Pot . _ => exception ... </k> [owise]
 
     syntax PotStep ::= "drip"
  // -------------------------

--- a/spot.md
+++ b/spot.md
@@ -43,7 +43,6 @@ Spot Semantics
     syntax SpotStep ::= SpotAuthStep
     syntax AuthStep ::= SpotContract "." SpotAuthStep [klabel(spotStep)]
  // --------------------------------------------------------------------
-    rule <k> Spot . _ => exception ... </k> [owise]
 
     syntax Event ::= Poke(String, Wad, Ray)
  // ---------------------------------------

--- a/strip-erroneous-labels.sh
+++ b/strip-erroneous-labels.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+input_definition="$1" && shift
+
+lines=( $(grep --line-number "symbol Lbl'Hash'EmptyK{}() :"     "$input_definition" | cut --delimiter=':' --field=1 | tail -n +2))
+lines+=($(grep --line-number "symbol Lbl'Hash'EmptyKList{}() :" "$input_definition" | cut --delimiter=':' --field=1 | tail -n +2))
+
+sed_command=''
+
+for line in ${lines[@]}; do
+    sed_command="${sed_command}${line}d;"
+done
+
+sed -i "$sed_command" "$input_definition"

--- a/vat.md
+++ b/vat.md
@@ -109,7 +109,6 @@ Updating the `<vat>` happens in phases:
     syntax VatStep ::= VatAuthStep
     syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]
  // -----------------------------------------------------------------
-    rule <k> Vat . _ => exception ... </k> [owise]
 ```
 
 ### Deactivation

--- a/vow.md
+++ b/vow.md
@@ -44,7 +44,6 @@ Vow Semantics
     syntax VowStep ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]
  // -----------------------------------------------------------------
-    rule <k> Vow . _ => exception ... </k> [owise]
 
     syntax VowAuthStep ::= "fess" Rad
  // ---------------------------------


### PR DESCRIPTION
-   Enable `Debug` build by default for speed.
-   Strip out erroneous labels added with haskell backend because of K-TERM hack in definition manually.
-   `transact` should have a source address, which is what `msg-sender` and `this` is set to initially.
-   `call` only updates `this`, but `msg-sender` remains unchanged.
-   Single global `owise` rule for throwing exceptions instead of per-file rules.