### PR TITLE
Add code for `file` methods, cleanups

### DIFF
--- a/dai.md
+++ b/dai.md
@@ -22,10 +22,9 @@ module DAI
           <dai-nonce>       .Map      </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
         </dai-state>
       </dai>
+```
 
-    syntax AllowanceAddress ::= "{" Address "->" Address "}"
- // --------------------------------------------------------
-
+```k
     syntax MCDContract ::= DaiContract
     syntax DaiContract ::= "Dai"
     syntax MCDStep ::= DaiContract "." DaiStep [klabel(daiStep)]
@@ -36,11 +35,33 @@ module DAI
     syntax DaiStep ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]
  // -----------------------------------------------------------------
+```
 
+Dai Data
+--------
+
+-   `AllowanceAddress` is a tuple of two addresses, representing that a given account allows a certain amount to be `transferFrom`ed by another account.
+
+```k
+    syntax AllowanceAddress ::= "{" Address "->" Address "}"
+ // --------------------------------------------------------
+```
+
+Dai Events
+----------
+
+```k
     syntax Event ::= Transfer(Address, Address, Wad)
                    | Approval(Address, Address, Wad)
  // ------------------------------------------------
+```
 
+Dai Semantics
+-------------
+
+The Dai token is a mintable/burnable ERC20 token.
+
+```k
     syntax DaiStep ::= "transfer" Address Wad
  // -----------------------------------------
     rule <k> Dai . transfer ACCOUNT_SRC AMOUNT => . ... </k>

--- a/end.md
+++ b/end.md
@@ -40,9 +40,6 @@ End Configuration
       </end-state>
 ```
 
-End Semantics
--------------
-
 ```k
     syntax MCDContract ::= EndContract
     syntax EndContract ::= "End"
@@ -54,7 +51,31 @@ End Semantics
     syntax EndStep ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]
  // -----------------------------------------------------------------
+```
 
+File-able Fields
+----------------
+
+These parameters are controlled by governance:
+
+-   `wait`: time buffer on `thaw` step.
+
+```k
+    syntax EndAuthStep ::= "file" EndFile
+ // -------------------------------------
+
+    syntax EndFile ::= "wait" Int
+ // -----------------------------
+    rule <k> End . file wait WAIT => . ... </k>
+         <end-wait> _ => WAIT </end-wait>
+```
+
+**NOTE**: We have not added `file` steps for `vat`, `cat`, `vow`, `pot`, or `spot` because this model does not deal with swapping out implementations.
+
+End Semantics
+-------------
+
+```k
     syntax EndAuthStep ::= "cage"
  // -----------------------------
     rule <k> End . cage

--- a/flap.md
+++ b/flap.md
@@ -9,11 +9,6 @@ module FLAP
     imports VAT
 ```
 
-```k
-    syntax Bid ::= FlapBid ( bid: Wad, lot: Rad, guy: Address, tic: Int, end: Int )
- // -------------------------------------------------------------------------------
-```
-
 Flap Configuration
 ------------------
 
@@ -44,10 +39,61 @@ Flap Semantics
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]
  // --------------------------------------------------------------------
+```
 
+Flap Data
+---------
+
+-   `FlapBid` tracks parameters of each auction:
+
+    -   `bid`: current high bid.
+    -   `lot`: quantity being bid on.
+    -   `guy`: current high bidder.
+    -   `tic`: expiration time of auction (updated on bids).
+    -   `end`: global expiration time of auction (set at start).
+
+```k
+    syntax Bid ::= FlapBid ( bid: Wad, lot: Rad, guy: Address, tic: Int, end: Int )
+ // -------------------------------------------------------------------------------
+```
+
+File-able Fields
+----------------
+
+The parameters controlled by governance are:
+
+-   `beg`: minimum increase in bid size.
+-   `ttl`: time increase for auction duration when receiving new bids.
+-   `tau`: total auction duration length.
+
+```k
+    syntax FlapAuthStep ::= "file" FlapFile
+ // ---------------------------------------
+
+    syntax FlapFile ::= "beg" Ray
+                      | "ttl" Int
+                      | "tau" Int
+ // -----------------------------
+    rule <k> Flap . file beg BEG => . ... </k>
+         <flap-beg> _ => BEG </flap-beg>
+
+    rule <k> Flap . file ttl TTL => . ... </k>
+         <flap-ttl> _ => TTL </flap-ttl>
+
+    rule <k> Flap . file tau TAU => . ... </k>
+         <flap-tau> _ => TAU </flap-tau>
+```
+
+Flap Events
+-----------
+
+```k
     syntax Event ::= FlapKick(Int, Rad, Wad)
  // ----------------------------------------
 ```
+
+Flap Semantics
+--------------
 
 - kick(uint lot, uint bid) returns (uint id)
 - Starts a new surplus auction for a lot amount

--- a/flip.md
+++ b/flip.md
@@ -7,11 +7,6 @@ module FLIP
     imports VAT
 ```
 
-```k
-    syntax Bid ::= FlipBid ( bid: Rad, lot: Wad, guy: Address, tic: Int, end: Int, usr: Address, gal: Address, tab: Rad )
- // ---------------------------------------------------------------------------------------------------------------------
-```
-
 Flip Configuration
 ------------------
 
@@ -30,9 +25,6 @@ Flip Configuration
       </flips>
 ```
 
-Flip Semantics
---------------
-
 ```k
     syntax MCDContract ::= FlipContract
     syntax FlipContract ::= "Flip" String
@@ -44,10 +36,78 @@ Flip Semantics
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]
  // --------------------------------------------------------------------
+```
 
+Flip Data
+---------
+
+-   `FlipBid` tracks parameters of a given Flipper auction:
+
+    -   `bid`: the current bid.
+    -   `lot`: the quantity being auctioned off.
+    -   `guy`: current high bidder.
+    -   `tic`: expiration time of auction (updated on bids).
+    -   `end`: global expiration time of auction (set at start).
+    -   `usr`: receives collateral gems from the auction.
+    -   `gal`: receives Dai from the auction.
+    -   `tab`: total Dai wanted for auction.
+
+```k
+    syntax Bid ::= FlipBid ( bid: Rad, lot: Wad, guy: Address, tic: Int, end: Int, usr: Address, gal: Address, tab: Rad )
+ // ---------------------------------------------------------------------------------------------------------------------
+```
+
+File-able Fields
+----------------
+
+The parameters controlled by governance are:
+
+-   `beg`: minimum increase in bid size.
+-   `ttl`: time increase for auction duration when receiving new bids.
+-   `tau`: total auction duration length.
+
+```k
+    syntax FlipAuthStep ::= "file" FlipFile
+ // ---------------------------------------
+
+    syntax FlipFile ::= "beg" Ray
+                      | "ttl" Int
+                      | "tau" Int
+ // -----------------------------
+    rule <k> Flip ILKID . file beg BEG => . ... </k>
+         <flip>
+           <flip-ilk> ILKID </flip-ilk>
+           <flip-beg> _ => BEG </flip-beg>
+           ...
+         </flip>
+
+    rule <k> Flip ILKID . file ttl TTL => . ... </k>
+         <flip>
+           <flip-ilk> ILKID </flip-ilk>
+           <flip-ttl> _ => TTL </flip-ttl>
+           ...
+         </flip>
+
+    rule <k> Flip ILKID . file tau TAU => . ... </k>
+         <flip>
+           <flip-ilk> ILKID </flip-ilk>
+           <flip-tau> _ => TAU </flip-tau>
+           ...
+         </flip>
+```
+
+Flip Events
+-----------
+
+```k
     syntax Event ::= FlipKick(Int, Wad, Rad, Rad, Address, Address)
  // ---------------------------------------------------------------
+```
 
+Flip Semantics
+--------------
+
+```k
     syntax FlipStep ::= "kick" Address Address Rad Wad Rad
  // ------------------------------------------------------
     rule <k> Flip ILK . kick USR GAL TAB LOT BID

--- a/flop.md
+++ b/flop.md
@@ -9,11 +9,6 @@ module FLOP
     imports VAT
 ```
 
-```k
-    syntax Bid ::= FlopBid ( bid: Rad, lot: Wad, guy: Address, tic: Int, end: Int )
- // -------------------------------------------------------------------------------
-```
-
 Flop Configuration
 ------------------
 
@@ -31,9 +26,6 @@ Flop Configuration
       </flop-state>
 ```
 
-Flop Semantics
---------------
-
 ```k
     syntax MCDContract ::= FlopContract
     syntax FlopContract ::= "Flop"
@@ -45,10 +37,66 @@ Flop Semantics
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
  // --------------------------------------------------------------------
+```
 
+Flop Data
+---------
+
+-   `FlopBid` tracks the parameters of an auction:
+
+    -   `bid`: current bid on auction.
+    -   `lot`: quantity being auctioned off.
+    -   `guy`: current high bidder.
+    -   `tic`: expiration date of an auction, extended on new bids.
+    -   `end`: global expiration date of an auction.
+
+```k
+    syntax Bid ::= FlopBid ( bid: Rad, lot: Wad, guy: Address, tic: Int, end: Int )
+ // -------------------------------------------------------------------------------
+```
+
+File-able Fields
+----------------
+
+The parameters controlled by governance are:
+
+-   `beg`: minimum increase in bid size.
+-   `ttl`: time increase for auction duration when receiving new bids.
+-   `tau`: total auction duration length.
+-   `pad`: lot increase factor for each `tick`.
+
+```k
+    syntax FlopAuthStep ::= "file" FlopFile
+ // ---------------------------------------
+
+    syntax FlopFile ::= "beg" Ray
+                      | "ttl" Int
+                      | "tau" Int
+                      | "pad" Ray
+ // -----------------------------
+    rule <k> Flop . file beg BEG => . ... </k>
+         <flop-beg> _ => BEG </flop-beg>
+
+    rule <k> Flop . file ttl TTL => . ... </k>
+         <flop-ttl> _ => TTL </flop-ttl>
+
+    rule <k> Flop . file tau TAU => . ... </k>
+         <flop-tau> _ => TAU </flop-tau>
+
+    rule <k> Flop . file pad PAD => . ... </k>
+         <flop-pad> _ => PAD </flop-pad>
+```
+
+Flop Events
+-----------
+
+```k
     syntax Event ::= FlopKick(Int, Wad, Rad, Address)
  // -------------------------------------------------
 ```
+
+Flop Semantics
+--------------
 
 - kick(address gal, uint lot, uint bid) returns (uint id)
 - Starts an auction

--- a/gem.md
+++ b/gem.md
@@ -19,9 +19,6 @@ Gem Configuration
       </gems>
 ```
 
-Gem Semantics
--------------
-
 ```k
     syntax MCDContract ::= GemContract
     syntax GemContract ::= "Gem" String
@@ -34,7 +31,12 @@ Gem Semantics
     syntax GemStep ::= GemAuthStep
     syntax AuthStep ::= GemContract "." GemAuthStep [klabel(gemStep)]
  // -----------------------------------------------------------------
+```
 
+Gem Semantics
+-------------
+
+```k
     syntax GemStep ::= "transferFrom" Address Address Wad
  // -----------------------------------------------------
     rule <k> Gem GEMID . transferFrom ACCTSRC ACCTDST VALUE => . ... </k>

--- a/join.md
+++ b/join.md
@@ -17,13 +17,13 @@ Join Configuration
 ```k
     configuration
       <join-state>
-        <gemJoins>
-          <gemJoin multiplicity="*" type="Map">
-            <gemJoin-gem> "" </gemJoin-gem>
-            <gemJoin-addr> 0:Address </gemJoin-addr>
-          </gemJoin>
-        </gemJoins>
-        <daiJoin-addr> 0:Address </daiJoin-addr>
+        <gem-joins>
+          <gem-join multiplicity="*" type="Map">
+            <gem-join-gem> "" </gem-join-gem>
+            <gem-join-addr> 0:Address </gem-join-addr>
+          </gem-join>
+        </gem-joins>
+        <dai-join-addr> 0:Address </dai-join-addr>
       </join-state>
 ```
 
@@ -36,7 +36,7 @@ Join Semantics
     syntax MCDStep ::= GemJoinContract "." GemJoinStep [klabel(gemJoinStep)]
  // ------------------------------------------------------------------------
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
-    rule [[ address(GemJoin GEMID) => ACCTJOIN ]] <gemJoin-gem> GEMID </gemJoin-gem> <gemJoin-addr> ACCTJOIN </gemJoin-addr>
+    rule [[ address(GemJoin GEMID) => ACCTJOIN ]] <gem-join-gem> GEMID </gem-join-gem> <gem-join-addr> ACCTJOIN </gem-join-addr>
 
     syntax GemJoinStep ::= "join" Address Wad
  // -----------------------------------------
@@ -60,7 +60,7 @@ Join Semantics
     syntax MCDStep ::= DaiJoinContract "." DaiJoinStep [klabel(daiJoinStep)]
  // ------------------------------------------------------------------------
     rule contract(DaiJoin . _) => DaiJoin
-    rule [[ address(DaiJoin) => ACCTJOIN ]] <daiJoin-addr> ACCTJOIN </daiJoin-addr>
+    rule [[ address(DaiJoin) => ACCTJOIN ]] <dai-join-addr> ACCTJOIN </dai-join-addr>
 
     syntax DaiJoinStep ::= "join" Address Wad
  // -----------------------------------------

--- a/join.md
+++ b/join.md
@@ -27,9 +27,6 @@ Join Configuration
       </join-state>
 ```
 
-Join Semantics
---------------
-
 ```k
     syntax MCDContract ::= GemJoinContract
     syntax GemJoinContract ::= "GemJoin" String
@@ -38,6 +35,18 @@ Join Semantics
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
     rule [[ address(GemJoin GEMID) => ACCTJOIN ]] <gem-join-gem> GEMID </gem-join-gem> <gem-join-addr> ACCTJOIN </gem-join-addr>
 
+    syntax MCDContract ::= DaiJoinContract
+    syntax DaiJoinContract ::= "DaiJoin"
+    syntax MCDStep ::= DaiJoinContract "." DaiJoinStep [klabel(daiJoinStep)]
+ // ------------------------------------------------------------------------
+    rule contract(DaiJoin . _) => DaiJoin
+    rule [[ address(DaiJoin) => ACCTJOIN ]] <dai-join-addr> ACCTJOIN </dai-join-addr>
+```
+
+Join Semantics
+--------------
+
+```k
     syntax GemJoinStep ::= "join" Address Wad
  // -----------------------------------------
     rule <k> GemJoin GEMID . join USR AMOUNT
@@ -54,13 +63,6 @@ Join Semantics
           ~> call Gem GEMID . transfer USR AMOUNT ... </k>
          <msg-sender> MSGSENDER </msg-sender>
       requires AMOUNT >=Rat 0
-
-    syntax MCDContract ::= DaiJoinContract
-    syntax DaiJoinContract ::= "DaiJoin"
-    syntax MCDStep ::= DaiJoinContract "." DaiJoinStep [klabel(daiJoinStep)]
- // ------------------------------------------------------------------------
-    rule contract(DaiJoin . _) => DaiJoin
-    rule [[ address(DaiJoin) => ACCTJOIN ]] <dai-join-addr> ACCTJOIN </dai-join-addr>
 
     syntax DaiJoinStep ::= "join" Address Wad
  // -----------------------------------------

--- a/jug.md
+++ b/jug.md
@@ -7,13 +7,6 @@ module JUG
     imports VAT
 ```
 
--   `JugIlk`: `DUTY`, `RHO`.
-
-```k
-    syntax JugIlk ::= Ilk ( duty: Ray, rho: Int )                    [klabel(#JugIlk), symbol]
- // ------------------------------------------------------------------------------------------
-```
-
 Jug Configuration
 -----------------
 
@@ -27,9 +20,6 @@ Jug Configuration
       </jug>
 ```
 
-Jug Semantics
--------------
-
 ```k
     syntax MCDContract ::= JugContract
     syntax JugContract ::= "Jug"
@@ -41,12 +31,59 @@ Jug Semantics
     syntax JugStep ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]
  // -----------------------------------------------------------------
+```
 
+Jug Data
+--------
+
+-   `JugIlk` tracks the ilk parameters for stability fee collection:
+
+    -   `duty`: risk premium used for calculating stability fee for this ilk.
+    -   `rho`: last time stability fee was collected for this ilk.
+
+```k
+    syntax JugIlk ::= Ilk ( duty: Ray, rho: Int ) [klabel(#JugIlk), symbol]
+ // -----------------------------------------------------------------------
+```
+
+File-able Fields
+----------------
+
+These parameters are controlled by governance:
+
+-   `duty`: risk premium for a given ilk.
+-   `base`: stability fee rate.
+-   `vow`: address which accumulates stability fees.
+
+```k
+    syntax JugAuthStep ::= "file" JugFile
+ // -------------------------------------
+
+    syntax JugFile ::= "duty" String Ray
+                     | "base" Ray
+                     | "vow-file" Address
+ // -------------------------------------
+    rule <k> Jug . file duty ILKID DUTY => . ... </k>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) ) ... </jug-ilks>
+
+    rule <k> Jug . file base BASE => . ... </k>
+         <jug-base> _ => BASE </jug-base>
+
+    rule <k> Jug . file vow-file ADDR => . ... </k>
+         <jug-vow> _ => ADDR </jug-vow>
+```
+
+**TODO**: Have to call it `vow-file` step to avoid conflict with `<vow>` cell.
+
+Jug Semantics
+-------------
+
+```k
     syntax JugAuthStep ::= InitStep
  // -------------------------------
     rule <k> Jug . init ILK => . ... </k>
          <currentTime> TIME </currentTime>
-         <jug-ilks> ... ILK |-> Ilk ( ILKDUTY => 1, _ => TIME ) ... </jug-ilks>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY => 1, rho: _ => TIME ) ... </jug-ilks>
       requires ILKDUTY ==Int 0
 ```
 
@@ -55,8 +92,8 @@ Jug Semantics
  // --------------------------------
     rule <k> Jug . drip ILK => call Vat . fold ILK ADDRESS ( ( (BASE +Rat ILKDUTY) ^Rat (TIME -Int ILKRHO) ) *Rat ILKRATE ) -Rat ILKRATE ... </k>
          <currentTime> TIME </currentTime>
-         <vat-ilks> ... ILK |-> Ilk ( _, ILKRATE, _, _, _ ) ... </vat-ilks>
-         <jug-ilks> ... ILK |-> Ilk ( ILKDUTY, ILKRHO => TIME ) ... </jug-ilks>
+         <vat-ilks> ... ILK |-> Ilk ( ... rate: ILKRATE ) ... </vat-ilks>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY, rho: ILKRHO => TIME ) ... </jug-ilks>
          <jug-vow> ADDRESS </jug-vow>
          <jug-base> BASE </jug-base>
       requires TIME >=Int ILKRHO

--- a/pot.md
+++ b/pot.md
@@ -24,9 +24,6 @@ Pot Configuration
       </pot>
 ```
 
-Pot Semantics
--------------
-
 ```k
     syntax MCDContract ::= PotContract
     syntax PotContract ::= "Pot"
@@ -38,7 +35,36 @@ Pot Semantics
     syntax PotStep ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]
  // -----------------------------------------------------------------
+```
 
+File-able Fields
+----------------
+
+These parameters are controlled by governance:
+
+-   `dsr`: interest rate of the Dai savings accounts.
+-   `vow`: where debt is accumulated to offset user savings.
+
+```k
+    syntax PotAuthStep ::= "file" PotFile
+ // -------------------------------------
+
+    syntax PotFile ::= "dsr" Ray
+                     | "vow-file" Address
+ // -------------------------------------
+    rule <k> Pot . file dsr DSR => . ... </k>
+         <pot-dsr> _ => DSR </pot-dsr>
+
+    rule <k> Pot . file vow-file ADDR => . ... </k>
+         <pot-vow> _ => ADDR </pot-vow>
+```
+
+**TODO**: Need to use `vow-file` as name to avoid conflict with `<vow>` cell.
+
+Pot Semantics
+-------------
+
+```k
     syntax PotStep ::= "drip"
  // -------------------------
     rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rat CHI *Rat ( DSR ^Rat (NOW -Int RHO) -Rat 1 ) ) ... </k>

--- a/vat.md
+++ b/vat.md
@@ -48,8 +48,8 @@ CDP Data
  // -----------------------------------------------------------------------
     rule urnBalance(ILK, URN) => urnCollateral(ILK, URN) -Rat urnDebt(ILK, URN)
 
-    rule urnDebt      (Ilk(_ , RATE , _    , _ , _), Urn( _   , ART )) => ART *Rat RATE
-    rule urnCollateral(Ilk(_ , _    , SPOT , _ , _), Urn( INK , _   )) => INK *Rat SPOT
+    rule urnDebt      (ILK, URN) => rate(ILK) *Rat art(URN)
+    rule urnCollateral(ILK, URN) => spot(ILK) *Rat ink(URN)
 ```
 
 Vat Configuration

--- a/vat.md
+++ b/vat.md
@@ -89,13 +89,6 @@ For convenience, total Dai/Sin are tracked:
 
 ### Vat Steps
 
-Updating the `<vat>` happens in phases:
-
--   Save off the current `<vat>`,
--   Check if either (i) this step does not need admin authorization or (ii) we are authorized to take this step,
--   Check that the `Vat.check` holds, and
--   Roll back state on failure.
-
 **TODO**: Should every `notBool isAuthStep` be subject to `Vat . live`?
 
 ```k
@@ -162,6 +155,7 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```
 
 -   `Vat.safe` checks that a given `Urn` of a certain `ilk` is not over-leveraged.
+-   `Vat.nondusty` checks that a given `Urn` has the minumum deposit (is effectively non-zero).
 
 ```k
     syntax VatStep ::= "safe" String Address

--- a/vat.md
+++ b/vat.md
@@ -8,34 +8,34 @@ module VAT
 CDP Data
 --------
 
--   `CDPID`: Identifies a given users `ilk` or `urn`.
+-   `VatIlk` tracks several parameters of a given `Ilk`:
 
-```k
-    syntax CDPID ::= "{" String "," Address "}"
- // -------------------------------------------
-```
-
--   `VatIlk`: `ART`, `RATE`, `SPOT`, `LINE`, `DUST`.
-
-Vat doesn't care about parameters for auctions, so only has stuff like debt ceiling, penalty, etc.
-Ok to say "this is the VatIlk, this is the CatIlk".
-"Could have one big `Ilk` type with all the parameters, but there are different types to project out relevant parts to those contracts."
-Getters and setters for `Ilk` should be permissioned, and different combinations of Contract + User might have `file` access to different fields (might be non-`file` access methods).
+    -   `Art`: Total debt across all `Address` for this `Ilk`.
+    -   `rate`: Debt scaling factor.
+    -   `spot`: Collateral scaling factor.
+    -   `line`: Maximum allowed scaled debt for this `Ilk`.
+    -   `dust`: Effectively zero (minimum) amount of debt allowed in this `Ilk`.
 
 ```k
     syntax VatIlk ::= Ilk ( Art: Wad , rate: Ray , spot: Ray , line: Rad , dust: Rad ) [klabel(#VatIlk), symbol]
  // ------------------------------------------------------------------------------------------------------------
 ```
 
--   `VatUrn`: `INK`, `ART`
+-   `CDPID`: Identifies a given `Ilk` (collateral type) for a given `Address` (user).
+-   `VatUrn` trackes a given CDP (collateralized-debt position) with parameters:
 
-`Urn` is individual CDP of a certain `Ilk` for a certain address (actual data that comprises a CDP).
-`Urn` has the exact same definition everywhere, so we can get away with a single definition.
+    -   `ink`: Total amount of collateral supporting the CDP.
+    -   `art`: Total amount of debt against the CDP.
 
 ```k
+    syntax CDPID ::= "{" String "," Address "}"
+ // -------------------------------------------
+
     syntax VatUrn ::= Urn ( ink: Wad , art: Wad ) [klabel(#VatUrn), symbol]
  // -----------------------------------------------------------------------
 ```
+
+### CDP Measurables
 
 -   `urnBalance` takes an `Urn` and it's corresponding `Ilk` and returns the "balance" of the `Urn` (`collateral - debt`).
 -   `urnDebt` calculates the `RATE`-scaled `ART` of an `Urn`.

--- a/vat.md
+++ b/vat.md
@@ -5,6 +5,26 @@ module VAT
     imports KMCD-DRIVER
 ```
 
+Vat Configuration
+-----------------
+
+```k
+    configuration
+      <vat>
+        <vat-addr> 0:Address </vat-addr>
+        <vat-can>  .Map      </vat-can>  // mapping (address (address => uint))       Address |-> Set
+        <vat-ilks> .Map      </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
+        <vat-urns> .Map      </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
+        <vat-gem>  .Map      </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
+        <vat-dai>  .Map      </vat-dai>  // mapping (address => uint256)              Address |-> Rad
+        <vat-sin>  .Map      </vat-sin>  // mapping (address => uint256)              Address |-> Rad
+        <vat-debt> 0:Rad     </vat-debt> // Total Dai Issued
+        <vat-vice> 0:Rad     </vat-vice> // Total Unbacked Dai
+        <vat-Line> 0:Rad     </vat-Line> // Total Debt Ceiling
+        <vat-live> true      </vat-live> // Access Flag
+      </vat>
+```
+
 CDP Data
 --------
 
@@ -50,26 +70,6 @@ CDP Data
 
     rule urnDebt      (ILK, URN) => rate(ILK) *Rat art(URN)
     rule urnCollateral(ILK, URN) => spot(ILK) *Rat ink(URN)
-```
-
-Vat Configuration
------------------
-
-```k
-    configuration
-      <vat>
-        <vat-addr> 0:Address </vat-addr>
-        <vat-can>  .Map      </vat-can>  // mapping (address (address => uint))       Address |-> Set
-        <vat-ilks> .Map      </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
-        <vat-urns> .Map      </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
-        <vat-gem>  .Map      </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
-        <vat-dai>  .Map      </vat-dai>  // mapping (address => uint256)              Address |-> Rad
-        <vat-sin>  .Map      </vat-sin>  // mapping (address => uint256)              Address |-> Rad
-        <vat-debt> 0:Rad     </vat-debt> // Total Dai Issued
-        <vat-vice> 0:Rad     </vat-vice> // Total Unbacked Dai
-        <vat-Line> 0:Rad     </vat-Line> // Total Debt Ceiling
-        <vat-live> true      </vat-live> // Access Flag
-      </vat>
 ```
 
 Vat Semantics

--- a/vow.md
+++ b/vow.md
@@ -30,9 +30,6 @@ Vow Configuration
       </vow>
 ```
 
-Vow Semantics
--------------
-
 ```k
     syntax MCDContract ::= VowContract
     syntax VowContract ::= "Vow"
@@ -44,7 +41,49 @@ Vow Semantics
     syntax VowStep ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]
  // -----------------------------------------------------------------
+```
 
+File-able Data
+--------------
+
+These praameters are set by governance:
+
+-   `wait`: delay before `flog`ing is allowed.
+-   `bump`: Flap auction lot size.
+-   `hump`: Buffer on Flap auction lot size.
+-   `sump`: Flop auction initial bid.
+-   `dump`: Flop auction lot size.
+
+```k
+    syntax VowAuthStep ::= "file" VowFile
+ // -------------------------------------
+
+    syntax VowFile ::= "wait" Int
+                     | "bump" Rad
+                     | "hump" Rad
+                     | "sump" Rad
+                     | "dump" Wad
+ // -----------------------------
+    rule <k> Vow . file wait WAIT => . ... </k>
+         <vow-wait> _ => WAIT </vow-wait>
+
+    rule <k> Vow . file bump BUMP => . ... </k>
+         <vow-bump> _ => BUMP </vow-bump>
+
+    rule <k> Vow . file hump HUMP => . ... </k>
+         <vow-hump> _ => HUMP </vow-hump>
+
+    rule <k> Vow . file sump SUMP => . ... </k>
+         <vow-sump> _ => SUMP </vow-sump>
+
+    rule <k> Vow . file dump DUMP => . ... </k>
+         <vow-dump> _ => DUMP </vow-dump>
+```
+
+Vow Semantics
+-------------
+
+```k
     syntax VowAuthStep ::= "fess" Rad
  // ---------------------------------
     rule <k> Vow . fess TAB => . ... </k>


### PR DESCRIPTION
-   Organize each semantics file slightly (generic infra first, then datastructures, then file-able fields, then events, then semantics).
-   Add documentation for all data-structures.
-   Add `file` methods as `auth` methods in the model, and documentation of each file-able parameter.
-   Some simple changes to naming schemes.