### PR TITLE
Global authentication/ward scheme

### DIFF
--- a/cat.md
+++ b/cat.md
@@ -30,7 +30,6 @@ Cat Configuration
     syntax MCDStep ::= CatContract "." CatStep [klabel(catStep)]
  // ------------------------------------------------------------
     rule contract(Cat . _) => Cat
-    rule address(Cat) => "CAT"
 ```
 
 Cat Authorization
@@ -76,7 +75,7 @@ Cat Events
     syntax CatStep ::= "emitBite" String Address Wad Wad Wad
  // --------------------------------------------------------
     rule <k> ID:Int ~> emitBite ILK URN INK ART TAB => ID ... </k>
-         <frame-events> _ => ListItem(Bite(ILK, URN, INK, ART, TAB, address(Flip ILK), ID)) </frame-events>
+         <frame-events> _ => ListItem(Bite(ILK, URN, INK, ART, TAB, Flip ILK, ID)) </frame-events>
 ```
 
 File-able Fields

--- a/cat.md
+++ b/cat.md
@@ -17,9 +17,10 @@ Cat Configuration
 ```k
     configuration
       <cat>
-        <cat-ilks> .Map      </cat-ilks>
-        <cat-live> true      </cat-live>
-        <cat-vow>  0:Address </cat-vow>
+        <cat-wards> .Set      </cat-wards>
+        <cat-ilks>  .Map      </cat-ilks>
+        <cat-live>  true      </cat-live>
+        <cat-vow>   0:Address </cat-vow>
       </cat>
 ```
 
@@ -30,6 +31,7 @@ Cat Configuration
  // ------------------------------------------------------------
     rule contract(Cat . _) => Cat
     rule address(Cat) => "CAT"
+    rule [[ wards(Cat) => WARDS ]] <cat-wards> WARDS </cat-wards>
 
     syntax CatStep ::= CatAuthStep
     syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]

--- a/cat.md
+++ b/cat.md
@@ -31,11 +31,24 @@ Cat Configuration
  // ------------------------------------------------------------
     rule contract(Cat . _) => Cat
     rule address(Cat) => "CAT"
-    rule [[ wards(Cat) => WARDS ]] <cat-wards> WARDS </cat-wards>
+```
 
-    syntax CatStep ::= CatAuthStep
+Cat Authorization
+-----------------
+
+```k
+    syntax CatStep  ::= CatAuthStep
     syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Cat) => WARDS ]] <cat-wards> WARDS </cat-wards>
+
+    syntax CatAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Cat . rely ADDR => . ... </k>
+         <cat-wards> ... (.Set => SetItem(ADDR)) </cat-wards>
+
+    rule <k> Cat . deny ADDR => . ... </k>
+         <cat-wards> WARDS => WARDS -Set SetItem(ADDR) </cat-wards>
 ```
 
 Cat Data

--- a/cat.md
+++ b/cat.md
@@ -17,7 +17,6 @@ Cat Configuration
 ```k
     configuration
       <cat>
-        <cat-addr> 0:Address </cat-addr>
         <cat-ilks> .Map      </cat-ilks>
         <cat-live> true      </cat-live>
         <cat-vow>  0:Address </cat-vow>
@@ -30,7 +29,7 @@ Cat Configuration
     syntax MCDStep ::= CatContract "." CatStep [klabel(catStep)]
  // ------------------------------------------------------------
     rule contract(Cat . _) => Cat
-    rule [[ address(Cat) => ADDR ]] <cat-addr> ADDR </cat-addr>
+    rule address(Cat) => "CAT"
 
     syntax CatStep ::= CatAuthStep
     syntax AuthStep ::= CatContract "." CatAuthStep [klabel(catStep)]

--- a/dai.md
+++ b/dai.md
@@ -29,11 +29,24 @@ module DAI
  // ------------------------------------------------------------
     rule contract(Dai . _) => Dai
     rule address(Dai) => "DAI"
-    rule [[ wards(Dai) => WARDS ]] <dai-wards> WARDS </dai-wards>
+```
 
-    syntax DaiStep ::= DaiAuthStep
+Dai Authorization
+-----------------
+
+```k
+    syntax DaiStep  ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Dai) => WARDS ]] <dai-wards> WARDS </dai-wards>
+
+    syntax DaiAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Dai . rely ADDR => . ... </k>
+         <dai-wards> ... (.Set => SetItem(ADDR)) </dai-wards>
+
+    rule <k> Dai . deny ADDR => . ... </k>
+         <dai-wards> WARDS => WARDS -Set SetItem(ADDR) </dai-wards>
 ```
 
 Dai Data

--- a/dai.md
+++ b/dai.md
@@ -28,7 +28,6 @@ module DAI
     syntax MCDStep ::= DaiContract "." DaiStep [klabel(daiStep)]
  // ------------------------------------------------------------
     rule contract(Dai . _) => Dai
-    rule address(Dai) => "DAI"
 ```
 
 Dai Authorization

--- a/dai.md
+++ b/dai.md
@@ -13,13 +13,12 @@ module DAI
 
     configuration
       <dai>
-        <dai-state>
-          <dai-totalSupply> 0:Wad </dai-totalSupply>
-          <dai-account-id>  0     </dai-account-id>
-          <dai-balance>     .Map  </dai-balance>     // mapping (address => uint)                      Address |-> Wad
-          <dai-allowance>   .Map  </dai-allowance>   // mapping (address => mapping (address => uint))
-          <dai-nonce>       .Map  </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
-        </dai-state>
+        <dai-wards>       .Set  </dai-wards>
+        <dai-totalSupply> 0:Wad </dai-totalSupply>
+        <dai-account-id>  0     </dai-account-id>
+        <dai-balance>     .Map  </dai-balance>     // mapping (address => uint)                      Address |-> Wad
+        <dai-allowance>   .Map  </dai-allowance>   // mapping (address => mapping (address => uint))
+        <dai-nonce>       .Map  </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
       </dai>
 ```
 
@@ -30,6 +29,7 @@ module DAI
  // ------------------------------------------------------------
     rule contract(Dai . _) => Dai
     rule address(Dai) => "DAI"
+    rule [[ wards(Dai) => WARDS ]] <dai-wards> WARDS </dai-wards>
 
     syntax DaiStep ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]

--- a/dai.md
+++ b/dai.md
@@ -14,12 +14,11 @@ module DAI
     configuration
       <dai>
         <dai-state>
-          <dai-addr>        0:Address </dai-addr>
-          <dai-totalSupply> 0:Wad      </dai-totalSupply>
-          <dai-account-id>  0         </dai-account-id>
-          <dai-balance>     .Map      </dai-balance>     // mapping (address => uint)                      Address |-> Wad
-          <dai-allowance>   .Map      </dai-allowance>   // mapping (address => mapping (address => uint))
-          <dai-nonce>       .Map      </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
+          <dai-totalSupply> 0:Wad </dai-totalSupply>
+          <dai-account-id>  0     </dai-account-id>
+          <dai-balance>     .Map  </dai-balance>     // mapping (address => uint)                      Address |-> Wad
+          <dai-allowance>   .Map  </dai-allowance>   // mapping (address => mapping (address => uint))
+          <dai-nonce>       .Map  </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
         </dai-state>
       </dai>
 ```
@@ -30,7 +29,7 @@ module DAI
     syntax MCDStep ::= DaiContract "." DaiStep [klabel(daiStep)]
  // ------------------------------------------------------------
     rule contract(Dai . _) => Dai
-    rule [[ address(Dai) => ADDR ]] <dai-addr> ADDR </dai-addr>
+    rule address(Dai) => "DAI"
 
     syntax DaiStep ::= DaiAuthStep
     syntax AuthStep ::= DaiContract "." DaiAuthStep [klabel(daiStep)]

--- a/end.md
+++ b/end.md
@@ -46,7 +46,6 @@ End Configuration
     syntax MCDStep ::= EndContract "." EndStep [klabel(endStep)]
  // ------------------------------------------------------------
     rule contract(End . _) => End
-    rule address(End) => "END"
 ```
 
 End Authorization
@@ -123,11 +122,11 @@ End Semantics
     syntax EndStep ::= "skip" String Int
  // ------------------------------------
     rule <k> End . skip ILK ID
-          => call Vat . suck address(Vow) address(Vow) TAB
-          ~> call Vat . suck address(Vow) THIS BID
-          ~> call Vat . hope address(Flip ILK)
+          => call Vat . suck Vow Vow  TAB
+          ~> call Vat . suck Vow THIS BID
+          ~> call Vat . hope Flip ILK
           ~> call Flip ILK . yank ID
-          ~> call Vat . grab ILK USR THIS address(Vow) LOT (TAB /Rat RATE) ... </k>
+          ~> call Vat . grab ILK USR THIS Vow LOT (TAB /Rat RATE) ... </k>
          <this> THIS </this>
          <end-tag>
           ...
@@ -157,7 +156,7 @@ End Semantics
     syntax EndStep ::= "skim" String Address
  // ----------------------------------------
     rule <k> End . skim ILK URN
-          => call Vat . grab ILK URN THIS address(Vow) (0 -Rat minRat(INK, ART *Rat RATE *Rat TAG)) (0 -Rat ART) ... </k>
+          => call Vat . grab ILK URN THIS Vow (0 -Rat minRat(INK, ART *Rat RATE *Rat TAG)) (0 -Rat ART) ... </k>
          <this> THIS </this>
          <end-tag>
           ...
@@ -184,7 +183,7 @@ End Semantics
     syntax EndStep ::= "free" String
  // --------------------------------
     rule <k> End . free ILK
-          => call Vat . grab ILK MSGSENDER MSGSENDER address(Vow) (0 -Rat INK) 0 ... </k>
+          => call Vat . grab ILK MSGSENDER MSGSENDER Vow (0 -Rat INK) 0 ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <end-live> false </end-live>
          <vat-urns>
@@ -204,7 +203,7 @@ End Semantics
          <end-wait> WAIT </end-wait>
          <vat-dai>
            ...
-           address(Vow) |-> 0
+           Vow |-> 0
            ...
          </vat-dai>
          <vat-debt> DEBT </vat-debt>
@@ -242,7 +241,7 @@ End Semantics
     syntax EndStep ::= "pack" Wad
  // -----------------------------
     rule <k> End . pack AMOUNT
-          => call Vat . move MSGSENDER address(Vow) AMOUNT ... </k>
+          => call Vat . move MSGSENDER Vow AMOUNT ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <end-debt> DEBT </end-debt>
          <end-bag>

--- a/end.md
+++ b/end.md
@@ -83,7 +83,7 @@ End Semantics
           ~> call Cat . cage
           ~> call Vow . cage
           ~> call Pot . cage ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <end-live> true => false </end-live>
          <end-when> _ => NOW </end-when>
 
@@ -183,7 +183,7 @@ End Semantics
     syntax EndStep ::= "thaw"
  // -------------------------
     rule <k> End . thaw ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <end-live> false </end-live>
          <end-debt> 0 => DEBT </end-debt>
          <end-when> WHEN </end-when>

--- a/end.md
+++ b/end.md
@@ -25,17 +25,16 @@ End Configuration
       <end-state>
         <endPhase> false </endPhase>
         <end>
-          <end-addr> 0:Address </end-addr>
-          <end-live> true      </end-live>
-          <end-when> 0         </end-when>
-          <end-wait> 0         </end-wait>
-          <end-debt> 0:Rad      </end-debt>
-          <end-tag>  .Map      </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-gap>  .Map      </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-art>  .Map      </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-fix>  .Map      </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-bag>  .Map      </end-bag>  // mapping (address => uint256)                      Address |-> Wad
-          <end-out>  .Map      </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
+          <end-live> true  </end-live>
+          <end-when> 0     </end-when>
+          <end-wait> 0     </end-wait>
+          <end-debt> 0:Rad </end-debt>
+          <end-tag>  .Map  </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-gap>  .Map  </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-art>  .Map  </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-fix>  .Map  </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-bag>  .Map  </end-bag>  // mapping (address => uint256)                      Address |-> Wad
+          <end-out>  .Map  </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
         </end>
       </end-state>
 ```
@@ -46,7 +45,7 @@ End Configuration
     syntax MCDStep ::= EndContract "." EndStep [klabel(endStep)]
  // ------------------------------------------------------------
     rule contract(End . _) => End
-    rule [[ address(End) => ADDR ]] <end-addr> ADDR </end-addr>
+    rule address(End) => "END"
 
     syntax EndStep ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]

--- a/end.md
+++ b/end.md
@@ -47,11 +47,24 @@ End Configuration
  // ------------------------------------------------------------
     rule contract(End . _) => End
     rule address(End) => "END"
-    rule [[ wards(End) => WARDS ]] <end-wards> WARDS </end-wards>
+```
 
-    syntax EndStep ::= EndAuthStep
+End Authorization
+-----------------
+
+```k
+    syntax EndStep  ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(End) => WARDS ]] <end-wards> WARDS </end-wards>
+
+    syntax EndAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> End . rely ADDR => . ... </k>
+         <end-wards> ... (.Set => SetItem(ADDR)) </end-wards>
+
+    rule <k> End . deny ADDR => . ... </k>
+         <end-wards> WARDS => WARDS -Set SetItem(ADDR) </end-wards>
 ```
 
 File-able Fields

--- a/end.md
+++ b/end.md
@@ -25,16 +25,17 @@ End Configuration
       <end-state>
         <endPhase> false </endPhase>
         <end>
-          <end-live> true  </end-live>
-          <end-when> 0     </end-when>
-          <end-wait> 0     </end-wait>
-          <end-debt> 0:Rad </end-debt>
-          <end-tag>  .Map  </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-gap>  .Map  </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-art>  .Map  </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-fix>  .Map  </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-bag>  .Map  </end-bag>  // mapping (address => uint256)                      Address |-> Wad
-          <end-out>  .Map  </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
+          <end-wards> .Set  </end-wards>
+          <end-live>  true  </end-live>
+          <end-when>  0     </end-when>
+          <end-wait>  0     </end-wait>
+          <end-debt>  0:Rad </end-debt>
+          <end-tag>   .Map  </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-gap>   .Map  </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-art>   .Map  </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-fix>   .Map  </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-bag>   .Map  </end-bag>  // mapping (address => uint256)                      Address |-> Wad
+          <end-out>   .Map  </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
         </end>
       </end-state>
 ```
@@ -46,6 +47,7 @@ End Configuration
  // ------------------------------------------------------------
     rule contract(End . _) => End
     rule address(End) => "END"
+    rule [[ wards(End) => WARDS ]] <end-wards> WARDS </end-wards>
 
     syntax EndStep ::= EndAuthStep
     syntax AuthStep ::= EndContract "." EndAuthStep [klabel(endStep)]

--- a/flap.md
+++ b/flap.md
@@ -108,7 +108,7 @@ Flap Semantics
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flap-bids>... .Map =>
             KICKS +Int 1 |-> FlapBid(... bid: BID,
                                          lot: LOT,
@@ -129,7 +129,7 @@ Flap Semantics
     syntax FlapStep ::= "tick" Int [klabel(FlapTick),symbol]
  // --------------------------------------------------------
     rule <k> Flap . tick ID => . ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flap-bids>...
            ID |-> FlapBid(... tic: 0, end: END => NOW +Int TAU)
          ...</flap-bids>
@@ -150,7 +150,7 @@ Flap Semantics
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flap-bids>...
            ID |-> FlapBid(... bid: BID' => BID,
                               lot: LOT',
@@ -180,7 +180,7 @@ Flap Semantics
          ...
          </k>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flap-bids>...
            ID |-> FlapBid(... bid: BID, lot: LOT, guy: GUY, tic: TIC, end: END) => .Map
          ...</flap-bids>

--- a/flap.md
+++ b/flap.md
@@ -15,7 +15,8 @@ Flap Configuration
 ```k
     configuration
       <flap-state>
-        <flap-bids> .Map          </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
+        <flap-wards> .Set         </flap-wards>
+        <flap-bids>  .Map         </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
         <flap-kicks> 0            </flap-kicks>
         <flap-live>  true         </flap-live>
         <flap-beg>   105 /Rat 100 </flap-beg>
@@ -34,6 +35,7 @@ Flap Semantics
  // ---------------------------------------------------------------
     rule contract(Flap . _) => Flap
     rule address(Flap) => "FLAP"
+    rule [[ wards(Flap) => WARDS ]] <flap-wards> WARDS </flap-wards>
 
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]

--- a/flap.md
+++ b/flap.md
@@ -35,11 +35,24 @@ Flap Semantics
  // ---------------------------------------------------------------
     rule contract(Flap . _) => Flap
     rule address(Flap) => "FLAP"
-    rule [[ wards(Flap) => WARDS ]] <flap-wards> WARDS </flap-wards>
+```
 
+Flap Authorization
+------------------
+
+```k
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]
  // --------------------------------------------------------------------
+    rule [[ wards(Flap) => WARDS ]] <flap-wards> WARDS </flap-wards>
+
+    syntax FlapAuthStep ::= WardStep
+ // --------------------------------
+    rule <k> Flap . rely ADDR => . ... </k>
+         <flap-wards> ... (.Set => SetItem(ADDR)) </flap-wards>
+
+    rule <k> Flap . deny ADDR => . ... </k>
+         <flap-wards> WARDS => WARDS -Set SetItem(ADDR) </flap-wards>
 ```
 
 Flap Data

--- a/flap.md
+++ b/flap.md
@@ -15,7 +15,6 @@ Flap Configuration
 ```k
     configuration
       <flap-state>
-        <flap-addr>  0:Address    </flap-addr>
         <flap-bids> .Map          </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
         <flap-kicks> 0            </flap-kicks>
         <flap-live>  true         </flap-live>
@@ -34,7 +33,7 @@ Flap Semantics
     syntax MCDStep ::= FlapContract "." FlapStep [klabel(flapStep)]
  // ---------------------------------------------------------------
     rule contract(Flap . _) => Flap
-    rule [[ address(Flap) => ADDR ]] <flap-addr> ADDR </flap-addr>
+    rule address(Flap) => "FLAP"
 
     syntax FlapStep ::= FlapAuthStep
     syntax AuthStep ::= FlapContract "." FlapAuthStep [klabel(flapStep)]

--- a/flap.md
+++ b/flap.md
@@ -34,7 +34,6 @@ Flap Semantics
     syntax MCDStep ::= FlapContract "." FlapStep [klabel(flapStep)]
  // ---------------------------------------------------------------
     rule contract(Flap . _) => Flap
-    rule address(Flap) => "FLAP"
 ```
 
 Flap Authorization

--- a/flip.md
+++ b/flip.md
@@ -15,6 +15,7 @@ Flip Configuration
       <flips>
         <flip multiplicity="*" type="Map">
           <flip-ilk>   ""           </flip-ilk>
+          <flip-wards> .Set         </flip-wards>
           <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> FlipBid
           <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
           <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime
@@ -29,8 +30,9 @@ Flip Configuration
     syntax FlipContract ::= "Flip" String
     syntax MCDStep ::= FlipContract "." FlipStep [klabel(flipStep)]
  // ---------------------------------------------------------------
-    rule contract(Flip ILK . _) => Flip ILK
-    rule address(Flip ILK) => "FLIP-" +String ILK
+    rule contract(Flip ILKID . _) => Flip ILKID
+    rule address(Flip ILKID) => "FLIP-" +String ILKID
+    rule [[ wards(Flip ILKID) => WARDS ]] <flip> <flip-ilk> ILKID </flip-ilk> <flip-wards> WARDS </flip-wards> ... </flip>
 
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]

--- a/flip.md
+++ b/flip.md
@@ -32,11 +32,32 @@ Flip Configuration
  // ---------------------------------------------------------------
     rule contract(Flip ILKID . _) => Flip ILKID
     rule address(Flip ILKID) => "FLIP-" +String ILKID
-    rule [[ wards(Flip ILKID) => WARDS ]] <flip> <flip-ilk> ILKID </flip-ilk> <flip-wards> WARDS </flip-wards> ... </flip>
+```
 
+Flip Authorization
+------------------
+
+```k
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]
  // --------------------------------------------------------------------
+    rule [[ wards(Flip ILKID) => WARDS ]] <flip> <flip-ilk> ILKID </flip-ilk> <flip-wards> WARDS </flip-wards> ... </flip>
+
+    syntax FlipAuthStep ::= WardStep
+ // --------------------------------
+    rule <k> Flip ILKID . rely ADDR => . ... </k>
+         <flip>
+           <flip-ilk> ILKID </flip-ilk>
+           <flip-wards> ... (.Set => SetItem(ADDR)) </flip-wards>
+           ...
+         </flip>
+
+    rule <k> Flip ILKID . deny ADDR => . ... </k>
+         <flip>
+           <flip-ilk> ILKID </flip-ilk>
+           <flip-wards> WARDS => WARDS -Set SetItem(ADDR) </flip-wards>
+           ...
+         </flip>
 ```
 
 Flip Data

--- a/flip.md
+++ b/flip.md
@@ -31,7 +31,6 @@ Flip Configuration
     syntax MCDStep ::= FlipContract "." FlipStep [klabel(flipStep)]
  // ---------------------------------------------------------------
     rule contract(Flip ILKID . _) => Flip ILKID
-    rule address(Flip ILKID) => "FLIP-" +String ILKID
 ```
 
 Flip Authorization

--- a/flip.md
+++ b/flip.md
@@ -115,7 +115,7 @@ Flip Semantics
           ~> KICKS +Int 1 ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flip-ilk> ILK </flip-ilk>
          <flip-tau> TAU </flip-tau>
          <flip-kicks> KICKS => KICKS +Int 1 </flip-kicks>
@@ -135,7 +135,7 @@ Flip Semantics
     syntax FlipStep ::= "tick" Int
  // ------------------------------
     rule <k> Flip ILK . tick ID => . ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flip-ilk> ILK </flip-ilk>
          <flip-tau> TAU </flip-tau>
          <flip-bids>...
@@ -150,7 +150,7 @@ Flip Semantics
           => call Vat . move MSGSENDER GUY BID'
           ~> call Vat . move MSGSENDER GAL (BID -Rat BID') ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flip-ilk> ILK </flip-ilk>
          <flip-beg> BEG </flip-beg>
          <flip-ttl> TTL </flip-ttl>
@@ -178,7 +178,7 @@ Flip Semantics
           ~> call Vat.flux ILK THIS USR (LOT' -Rat LOT) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flip-ilk> ILK </flip-ilk>
          <flip-beg> BEG </flip-beg>
          <flip-ttl> TTL </flip-ttl>
@@ -203,7 +203,7 @@ Flip Semantics
  // ------------------------------
     rule <k> Flip ILK . deal ID => call Vat . flux ILK THIS GUY LOT ... </k>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flip-ilk> ILK </flip-ilk>
          <flip-bids>...
            ID |-> FlipBid(... lot: LOT, guy: GUY, tic: TIC, end: END) => .Map

--- a/flip.md
+++ b/flip.md
@@ -15,7 +15,6 @@ Flip Configuration
       <flips>
         <flip multiplicity="*" type="Map">
           <flip-ilk>   ""           </flip-ilk>
-          <flip-addr>  0:Address    </flip-addr>
           <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid)     Int     |-> FlipBid
           <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
           <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime
@@ -31,7 +30,7 @@ Flip Configuration
     syntax MCDStep ::= FlipContract "." FlipStep [klabel(flipStep)]
  // ---------------------------------------------------------------
     rule contract(Flip ILK . _) => Flip ILK
-    rule [[ address(Flip ILK) => ADDR ]] <flip-ilk> ILK </flip-ilk> <flip-addr> ADDR </flip-addr>
+    rule address(Flip ILK) => "FLIP-" +String ILK
 
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]

--- a/flop.md
+++ b/flop.md
@@ -110,7 +110,7 @@ Flop Semantics
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flop-live> true </flop-live>
          <flop-bids>... .Map =>
            KICKS +Int 1 |-> FlopBid(... bid: BID,
@@ -131,7 +131,7 @@ Flop Semantics
     syntax FlopStep ::= "tick" Int
  // ------------------------------
     rule <k> Flop . tick ID => . ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flop-bids> ... ID |-> FlopBid(... lot: LOT => LOT *Rat PAD, tic: 0, end: END => NOW +Int TAU ) ... </flop-bids>
          <flop-pad> PAD </flop-pad>
          <flop-tau> TAU </flop-tau>
@@ -149,7 +149,7 @@ Flop Semantics
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flop-bids>...
            ID |-> FlopBid(... bid: BID',
                               lot: LOT' => LOT,
@@ -177,7 +177,7 @@ Flop Semantics
           => call Gem "MKR" . mint GUY LOT
          ...
          </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <flop-bids>...
            ID |-> FlopBid(... lot: LOT, guy: GUY, tic: TIC, end: END) => .Map
          ...</flop-bids>

--- a/flop.md
+++ b/flop.md
@@ -15,7 +15,6 @@ Flop Configuration
 ```k
     configuration
       <flop-state>
-        <flop-addr>  0:Address    </flop-addr>
         <flop-bids> .Map          </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
         <flop-kicks> 0            </flop-kicks>
         <flop-live>  true         </flop-live>
@@ -32,7 +31,7 @@ Flop Configuration
     syntax MCDStep ::= FlopContract "." FlopStep [klabel(flopStep)]
  // ---------------------------------------------------------------
     rule contract(Flop . _) => Flop
-    rule [[ address(Flop) => ADDR ]] <flop-addr> ADDR </flop-addr>
+    rule address(Flop) => "FLOP"
 
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]

--- a/flop.md
+++ b/flop.md
@@ -15,13 +15,14 @@ Flop Configuration
 ```k
     configuration
       <flop-state>
-        <flop-bids> .Map          </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
-        <flop-kicks> 0            </flop-kicks>
-        <flop-live>  true         </flop-live>
-        <flop-beg>   105 /Rat 100 </flop-beg>
-        <flop-pad>   150 /Rat 100 </flop-pad>
-        <flop-ttl>   3 hours      </flop-ttl>
-        <flop-tau>   2 days       </flop-tau>
+        <flop-wards> .Set          </flop-wards>
+        <flop-bids>  .Map          </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
+        <flop-kicks>  0            </flop-kicks>
+        <flop-live>   true         </flop-live>
+        <flop-beg>    105 /Rat 100 </flop-beg>
+        <flop-pad>    150 /Rat 100 </flop-pad>
+        <flop-ttl>    3 hours      </flop-ttl>
+        <flop-tau>    2 days       </flop-tau>
       </flop-state>
 ```
 
@@ -32,6 +33,7 @@ Flop Configuration
  // ---------------------------------------------------------------
     rule contract(Flop . _) => Flop
     rule address(Flop) => "FLOP"
+    rule [[ wards(Flop) => WARDS ]] <flop-wards> WARDS </flop-wards>
 
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]

--- a/flop.md
+++ b/flop.md
@@ -32,7 +32,6 @@ Flop Configuration
     syntax MCDStep ::= FlopContract "." FlopStep [klabel(flopStep)]
  // ---------------------------------------------------------------
     rule contract(Flop . _) => Flop
-    rule address(Flop) => "FLOP"
 ```
 
 Flop Authorization

--- a/flop.md
+++ b/flop.md
@@ -33,11 +33,24 @@ Flop Configuration
  // ---------------------------------------------------------------
     rule contract(Flop . _) => Flop
     rule address(Flop) => "FLOP"
-    rule [[ wards(Flop) => WARDS ]] <flop-wards> WARDS </flop-wards>
+```
 
+Flop Authorization
+------------------
+
+```k
     syntax FlopStep ::= FlopAuthStep
     syntax AuthStep ::= FlopContract "." FlopAuthStep [klabel(flopStep)]
  // --------------------------------------------------------------------
+    rule [[ wards(Flop) => WARDS ]] <flop-wards> WARDS </flop-wards>
+
+    syntax FlopAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Flop . rely ADDR => . ... </k>
+         <flop-wards> ... (.Set => SetItem(ADDR)) </flop-wards>
+
+    rule <k> Flop . deny ADDR => . ... </k>
+         <flop-wards> WARDS => WARDS -Set SetItem(ADDR) </flop-wards>
 ```
 
 Flop Data

--- a/gem.md
+++ b/gem.md
@@ -13,6 +13,7 @@ Gem Configuration
       <gems>
         <gem multiplicity="*" type="Map">
           <gem-id>       "":String </gem-id>
+          <gem-wards>    .Set      </gem-wards>
           <gem-balances> .Map      </gem-balances> // mapping (address => uint256) Address |-> Wad
         </gem>
       </gems>
@@ -25,6 +26,7 @@ Gem Configuration
  // ------------------------------------------------------------
     rule contract(Gem GEMID . _) => Gem GEMID
     rule address(Gem GEMID) => "GEM-" +String GEMID
+    rule [[ wards(Gem GEMID) => WARDS ]] <gem> <gem-id> GEMID </gem-id> <gem-wards> WARDS </gem-wards> ... </gem>
 
     syntax GemAuthStep
     syntax GemStep ::= GemAuthStep

--- a/gem.md
+++ b/gem.md
@@ -13,7 +13,6 @@ Gem Configuration
       <gems>
         <gem multiplicity="*" type="Map">
           <gem-id>       "":String </gem-id>
-          <gem-addr>     0:Address </gem-addr>
           <gem-balances> .Map      </gem-balances> // mapping (address => uint256) Address |-> Wad
         </gem>
       </gems>
@@ -25,7 +24,7 @@ Gem Configuration
     syntax MCDStep ::= GemContract "." GemStep [klabel(gemStep)]
  // ------------------------------------------------------------
     rule contract(Gem GEMID . _) => Gem GEMID
-    rule [[ address(Gem GEMID) => ACCTGEM ]] <gem-id> GEMID </gem-id> <gem-addr> ACCTGEM </gem-addr>
+    rule address(Gem GEMID) => "GEM-" +String GEMID
 
     syntax GemAuthStep
     syntax GemStep ::= GemAuthStep

--- a/gem.md
+++ b/gem.md
@@ -25,7 +25,6 @@ Gem Configuration
     syntax MCDStep ::= GemContract "." GemStep [klabel(gemStep)]
  // ------------------------------------------------------------
     rule contract(Gem GEMID . _) => Gem GEMID
-    rule address(Gem GEMID) => "GEM-" +String GEMID
 ```
 
 Gem Authorization

--- a/gem.md
+++ b/gem.md
@@ -26,12 +26,32 @@ Gem Configuration
  // ------------------------------------------------------------
     rule contract(Gem GEMID . _) => Gem GEMID
     rule address(Gem GEMID) => "GEM-" +String GEMID
-    rule [[ wards(Gem GEMID) => WARDS ]] <gem> <gem-id> GEMID </gem-id> <gem-wards> WARDS </gem-wards> ... </gem>
+```
 
-    syntax GemAuthStep
-    syntax GemStep ::= GemAuthStep
+Gem Authorization
+-----------------
+
+```k
+    syntax GemStep  ::= GemAuthStep
     syntax AuthStep ::= GemContract "." GemAuthStep [klabel(gemStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Gem GEMID) => WARDS ]] <gem> <gem-id> GEMID </gem-id> <gem-wards> WARDS </gem-wards> ... </gem>
+
+    syntax GemAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Gem GEMID . rely ADDR => . ... </k>
+         <gem>
+           <gem-id> GEMID </gem-id>
+           <gem-wards> ... (.Set => SetItem(ADDR)) </gem-wards>
+           ...
+         </gem>
+
+    rule <k> Gem GEMID . deny ADDR => . ... </k>
+         <gem>
+           <gem-id> GEMID </gem-id>
+           <gem-wards> WARDS => WARDS -Set SetItem(ADDR) </gem-wards>
+           ...
+         </gem>
 ```
 
 Gem Semantics

--- a/join.md
+++ b/join.md
@@ -35,14 +35,12 @@ Join Configuration
     syntax MCDStep ::= GemJoinContract "." GemJoinStep [klabel(gemJoinStep)]
  // ------------------------------------------------------------------------
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
-    rule address(GemJoin GEMID) => "GEM-JOIN-" +String GEMID
 
     syntax MCDContract ::= DaiJoinContract
     syntax DaiJoinContract ::= "DaiJoin"
     syntax MCDStep ::= DaiJoinContract "." DaiJoinStep [klabel(daiJoinStep)]
  // ------------------------------------------------------------------------
     rule contract(DaiJoin . _) => DaiJoin
-    rule address(DaiJoin) => "DAI-JOIN"
 ```
 
 Join Authorization

--- a/join.md
+++ b/join.md
@@ -20,8 +20,12 @@ Join Configuration
         <gem-joins>
           <gem-join multiplicity="*" type="Map">
             <gem-join-gem> "" </gem-join-gem>
+            <gem-join-wards> .Set </gem-join-wards>
           </gem-join>
         </gem-joins>
+        <dai-join>
+          <dai-join-wards> .Set </dai-join-wards>
+        </dai-join>
       </join-state>
 ```
 
@@ -32,6 +36,7 @@ Join Configuration
  // ------------------------------------------------------------------------
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
     rule address(GemJoin GEMID) => "GEM-JOIN-" +String GEMID
+    rule [[ wards(GemJoin GEMID) => WARDS ]] <gem-join> <gem-join-gem> GEMID </gem-join-gem> <gem-join-wards> WARDS </gem-join-wards> ... </gem-join>
 
     syntax MCDContract ::= DaiJoinContract
     syntax DaiJoinContract ::= "DaiJoin"
@@ -39,6 +44,7 @@ Join Configuration
  // ------------------------------------------------------------------------
     rule contract(DaiJoin . _) => DaiJoin
     rule address(DaiJoin) => "DAI-JOIN"
+    rule [[ wards(DaiJoin) => WARDS ]] <dai-join-wards> WARDS </dai-join-wards>
 ```
 
 Join Semantics

--- a/join.md
+++ b/join.md
@@ -11,19 +11,7 @@ module JOIN
     imports VAT
 ```
 
-Join Configuration
-------------------
-
-```k
-    configuration
-      <join-state>
-        <gem-joins>
-          <gem-join multiplicity="*" type="Map">
-            <gem-join-gem> "" </gem-join-gem>
-          </gem-join>
-        </gem-joins>
-      </join-state>
-```
+No extra state is needed for the joiners, since they just register accounts with the relevant `<gem>` and offer some simple functionality.
 
 ```k
     syntax MCDContract ::= GemJoinContract

--- a/join.md
+++ b/join.md
@@ -11,7 +11,19 @@ module JOIN
     imports VAT
 ```
 
-No extra state is needed for the joiners, since they just register accounts with the relevant `<gem>` and offer some simple functionality.
+Join Configuration
+------------------
+
+```k
+    configuration
+      <join-state>
+        <gem-joins>
+          <gem-join multiplicity="*" type="Map">
+            <gem-join-gem> "" </gem-join-gem>
+          </gem-join>
+        </gem-joins>
+      </join-state>
+```
 
 ```k
     syntax MCDContract ::= GemJoinContract

--- a/join.md
+++ b/join.md
@@ -20,10 +20,8 @@ Join Configuration
         <gem-joins>
           <gem-join multiplicity="*" type="Map">
             <gem-join-gem> "" </gem-join-gem>
-            <gem-join-addr> 0:Address </gem-join-addr>
           </gem-join>
         </gem-joins>
-        <dai-join-addr> 0:Address </dai-join-addr>
       </join-state>
 ```
 
@@ -33,14 +31,14 @@ Join Configuration
     syntax MCDStep ::= GemJoinContract "." GemJoinStep [klabel(gemJoinStep)]
  // ------------------------------------------------------------------------
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
-    rule [[ address(GemJoin GEMID) => ACCTJOIN ]] <gem-join-gem> GEMID </gem-join-gem> <gem-join-addr> ACCTJOIN </gem-join-addr>
+    rule address(GemJoin GEMID) => "GEM-JOIN-" +String GEMID
 
     syntax MCDContract ::= DaiJoinContract
     syntax DaiJoinContract ::= "DaiJoin"
     syntax MCDStep ::= DaiJoinContract "." DaiJoinStep [klabel(daiJoinStep)]
  // ------------------------------------------------------------------------
     rule contract(DaiJoin . _) => DaiJoin
-    rule [[ address(DaiJoin) => ACCTJOIN ]] <dai-join-addr> ACCTJOIN </dai-join-addr>
+    rule address(DaiJoin) => "DAI-JOIN"
 ```
 
 Join Semantics

--- a/join.md
+++ b/join.md
@@ -36,7 +36,6 @@ Join Configuration
  // ------------------------------------------------------------------------
     rule contract(GemJoin GEMID . _) => GemJoin GEMID
     rule address(GemJoin GEMID) => "GEM-JOIN-" +String GEMID
-    rule [[ wards(GemJoin GEMID) => WARDS ]] <gem-join> <gem-join-gem> GEMID </gem-join-gem> <gem-join-wards> WARDS </gem-join-wards> ... </gem-join>
 
     syntax MCDContract ::= DaiJoinContract
     syntax DaiJoinContract ::= "DaiJoin"
@@ -44,7 +43,45 @@ Join Configuration
  // ------------------------------------------------------------------------
     rule contract(DaiJoin . _) => DaiJoin
     rule address(DaiJoin) => "DAI-JOIN"
+```
+
+Join Authorization
+------------------
+
+```k
+    syntax GemJoinStep ::= GemJoinAuthStep
+    syntax AuthStep    ::= GemJoinContract "." GemJoinAuthStep [klabel(gemJoinStep)]
+ // --------------------------------------------------------------------------------
+    rule [[ wards(GemJoin GEMID) => WARDS ]] <gem-join> <gem-join-gem> GEMID </gem-join-gem> <gem-join-wards> WARDS </gem-join-wards> ... </gem-join>
+
+    syntax GemJoinAuthStep ::= WardStep
+ // -----------------------------------
+    rule <k> GemJoin GEMID . rely ADDR => . ... </k>
+         <gem-join>
+           <gem-join-gem> GEMID </gem-join-gem>
+           <gem-join-wards> ... (.Set => SetItem(ADDR)) </gem-join-wards>
+           ...
+         </gem-join>
+
+    rule <k> GemJoin GEMID . deny ADDR => . ... </k>
+         <gem-join>
+           <gem-join-gem> GEMID </gem-join-gem>
+           <gem-join-wards> WARDS => WARDS -Set SetItem(ADDR) </gem-join-wards>
+           ...
+         </gem-join>
+
+    syntax DaiJoinStep ::= DaiJoinAuthStep
+    syntax AuthStep    ::= DaiJoinContract "." DaiJoinAuthStep [klabel(daiJoinStep)]
+ // --------------------------------------------------------------------------------
     rule [[ wards(DaiJoin) => WARDS ]] <dai-join-wards> WARDS </dai-join-wards>
+
+    syntax DaiJoinAuthStep ::= WardStep
+ // -----------------------------------
+    rule <k> DaiJoin . rely ADDR => . ... </k>
+         <dai-join-wards> ... (.Set => SetItem(ADDR)) </dai-join-wards>
+
+    rule <k> DaiJoin . deny ADDR => . ... </k>
+         <dai-join-wards> WARDS => WARDS -Set SetItem(ADDR) </dai-join-wards>
 ```
 
 Join Semantics

--- a/jug.md
+++ b/jug.md
@@ -13,9 +13,10 @@ Jug Configuration
 ```k
     configuration
       <jug>
-        <jug-ilks> .Map      </jug-ilks> // mapping (bytes32 => JugIlk) String  |-> JugIlk
-        <jug-vow>  0:Address </jug-vow>  //                             Address
-        <jug-base> 0:Ray     </jug-base> //                             Ray
+        <jug-wards> .Set      </jug-wards>
+        <jug-ilks>  .Map      </jug-ilks> // mapping (bytes32 => JugIlk) String  |-> JugIlk
+        <jug-vow>   0:Address </jug-vow>  //                             Address
+        <jug-base>  0:Ray     </jug-base> //                             Ray
       </jug>
 ```
 
@@ -26,6 +27,7 @@ Jug Configuration
  // ------------------------------------------------------------
     rule contract(Jug . _) => Jug
     rule address(Jug) => "JUG"
+    rule [[ wards(Jug) => WARDS ]] <jug-wards> WARDS </jug-wards>
 
     syntax JugStep ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]

--- a/jug.md
+++ b/jug.md
@@ -26,7 +26,6 @@ Jug Configuration
     syntax MCDStep ::= JugContract "." JugStep [klabel(jugStep)]
  // ------------------------------------------------------------
     rule contract(Jug . _) => Jug
-    rule address(Jug) => "JUG"
 ```
 
 Jug Authorization

--- a/jug.md
+++ b/jug.md
@@ -13,7 +13,6 @@ Jug Configuration
 ```k
     configuration
       <jug>
-        <jug-addr> 0:Address </jug-addr>
         <jug-ilks> .Map      </jug-ilks> // mapping (bytes32 => JugIlk) String  |-> JugIlk
         <jug-vow>  0:Address </jug-vow>  //                             Address
         <jug-base> 0:Ray     </jug-base> //                             Ray
@@ -26,7 +25,7 @@ Jug Configuration
     syntax MCDStep ::= JugContract "." JugStep [klabel(jugStep)]
  // ------------------------------------------------------------
     rule contract(Jug . _) => Jug
-    rule [[ address(Jug) => ADDR ]] <jug-addr> ADDR </jug-addr>
+    rule address(Jug) => "JUG"
 
     syntax JugStep ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]

--- a/jug.md
+++ b/jug.md
@@ -82,7 +82,7 @@ Jug Semantics
     syntax JugAuthStep ::= InitStep
  // -------------------------------
     rule <k> Jug . init ILK => . ... </k>
-         <currentTime> TIME </currentTime>
+         <current-time> TIME </current-time>
          <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY => 1, rho: _ => TIME ) ... </jug-ilks>
       requires ILKDUTY ==Int 0
 ```
@@ -91,7 +91,7 @@ Jug Semantics
     syntax JugStep ::= "drip" String
  // --------------------------------
     rule <k> Jug . drip ILK => call Vat . fold ILK ADDRESS ( ( (BASE +Rat ILKDUTY) ^Rat (TIME -Int ILKRHO) ) *Rat ILKRATE ) -Rat ILKRATE ... </k>
-         <currentTime> TIME </currentTime>
+         <current-time> TIME </current-time>
          <vat-ilks> ... ILK |-> Ilk ( ... rate: ILKRATE ) ... </vat-ilks>
          <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY, rho: ILKRHO => TIME ) ... </jug-ilks>
          <jug-vow> ADDRESS </jug-vow>

--- a/jug.md
+++ b/jug.md
@@ -27,11 +27,24 @@ Jug Configuration
  // ------------------------------------------------------------
     rule contract(Jug . _) => Jug
     rule address(Jug) => "JUG"
-    rule [[ wards(Jug) => WARDS ]] <jug-wards> WARDS </jug-wards>
+```
 
-    syntax JugStep ::= JugAuthStep
+Jug Authorization
+-----------------
+
+```k
+    syntax JugStep  ::= JugAuthStep
     syntax AuthStep ::= JugContract "." JugAuthStep [klabel(jugStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Jug) => WARDS ]] <jug-wards> WARDS </jug-wards>
+
+    syntax JugAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Jug . rely ADDR => . ... </k>
+         <jug-wards> ... (.Set => SetItem(ADDR)) </jug-wards>
+
+    rule <k> Jug . deny ADDR => . ... </k>
+         <jug-wards> WARDS => WARDS -Set SetItem(ADDR) </jug-wards>
 ```
 
 Jug Data

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -61,9 +61,7 @@ By default it's assumed that the special `ADMIN` account is authorized on all ot
 
     syntax Bool ::= isAuthorized ( Address , MCDContract ) [function]
  // -----------------------------------------------------------------
-    rule isAuthorized( _     , _           ) => false                      [owise]
-    rule isAuthorized( ADMIN , _           ) => true
-    rule isAuthorized( ADDR  , MCDCONTRACT ) => ADDR in wards(MCDCONTRACT) requires ADDR =/=K ADMIN
+    rule isAuthorized( ADDR , MCDCONTRACT ) => ADDR ==K ADMIN orBool ADDR in wards(MCDCONTRACT)
 
     syntax AuthStep
     syntax MCDStep ::= AuthStep

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -19,9 +19,9 @@ module KMCD-DRIVER
           <k> $PGM:MCDSteps </k>
           <msg-sender> 0:Address </msg-sender>
           <this> 0:Address </this>
-          <currentTime> 0:Int </currentTime>
-          <callStack> .List </callStack>
-          <preState> .K </preState>
+          <current-time> 0:Int </current-time>
+          <call-stack> .List </call-stack>
+          <pre-state> .K </pre-state>
           <events> .List </events>
           <frame-events> .List </frame-events>
         </kmcd-driver>
@@ -54,13 +54,13 @@ Function Calls
     rule <k> call AS:AuthStep ~> CONT => contract(AS) . auth ~> AS </k>
          <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(AS)) </this>
-         <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
+         <call-stack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </call-stack>
          <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, AS)) </frame-events>
 
     rule <k> call MCD:MCDStep ~> CONT => MCD </k>
          <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(MCD)) </this>
-         <callStack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </callStack>
+         <call-stack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </call-stack>
          <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires notBool isAuthStep(MCD)
 
@@ -69,14 +69,14 @@ Function Calls
     rule <k> R:ReturnValue => R ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
          <this> THIS => MSGSENDER </this>
-         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </callStack>
+         <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </call-stack>
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
     rule <k> . => CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
          <this> THIS => MSGSENDER </this>
-         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </callStack>
+         <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </call-stack>
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
@@ -94,11 +94,11 @@ Function Calls
     rule <k> exception E ~> _ => exception E ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
          <this> THIS => MSGSENDER </this>
-         <callStack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ...</callStack>
+         <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ...</call-stack>
          <frame-events> _ => PREVEVENTS </frame-events>
 
     rule <k> exception _ ~> dropState => popState ... </k>
-         <callStack> .List </callStack>
+         <call-stack> .List </call-stack>
 
     syntax MCStep ::= "pushState" | "dropState" | "popState"
  // --------------------------------------------------------
@@ -137,7 +137,7 @@ Some methods rely on a timestamp. We simulate that here.
     syntax MCDStep ::= "TimeStep"
  // -----------------------------
     rule <k> TimeStep => . ... </k>
-         <currentTime> TIME => TIME +Int 1 second </currentTime>
+         <current-time> TIME => TIME +Int 1 second </current-time>
 
     syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
  // --------------------------------------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -19,7 +19,6 @@ module KMCD-DRIVER
           <k> $PGM:MCDSteps </k>
           <msg-sender> 0:Address </msg-sender>
           <this> 0:Address </this>
-          <authorized-accounts> .Map </authorized-accounts>
           <current-time> 0:Int </current-time>
           <call-stack> .List </call-stack>
           <pre-state> .K </pre-state>
@@ -107,7 +106,6 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
     rule <k> call MCD:MCDStep ~> CONT => MCD </k>
          <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(MCD)) </this>
-         <authorized-accounts> AUTHS </authorized-accounts>
          <call-stack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </call-stack>
          <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires isAuthStep(MCD) impliesBool isAuthorized(THIS, contract(MCD))

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -185,6 +185,11 @@ We model everything with arbitrary precision rationals, but use sort information
 ```k
     syntax Address ::= Int | String
  // -------------------------------
+
+    syntax String ::= Address2String ( Address ) [function]
+ // -------------------------------------------------------
+    rule Address2String ( I:Int    ) => Int2String(I)
+    rule Address2String ( S:String ) => S
 ```
 
 ### Time Increments

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -139,6 +139,9 @@ Some methods rely on a timestamp. We simulate that here.
     rule <k> TimeStep => . ... </k>
          <currentTime> TIME => TIME +Int 1 second </currentTime>
 
+    syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
+ // --------------------------------------------------------
+
     syntax Int ::= Int "second"  [timeUnit]
                  | Int "seconds" [timeUnit]
                  | Int "minute"  [timeUnit]
@@ -147,10 +150,7 @@ Some methods rely on a timestamp. We simulate that here.
                  | Int "hours"   [timeUnit]
                  | Int "day"     [timeUnit]
                  | Int "days"    [timeUnit]
- // -------------------------
-
-    syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
-
+ // ---------------------------------------
     rule 1 second  => 1                    [macro]
     rule N seconds => N                    [macro]
     rule 1 minute  =>        60    seconds [macro]
@@ -159,6 +159,18 @@ Some methods rely on a timestamp. We simulate that here.
     rule N hours   => N *Int 3600  seconds [macro]
     rule 1 day     =>        86400 seconds [macro]
     rule N days    => N *Int 86400 seconds [macro]
+```
+
+Collateral Increments
+---------------------
+
+```k
+    syntax priorities collateralUnit > _+Int_ _-Int_ _*Int_ _/Int_
+ // --------------------------------------------------------------
+
+    syntax Int ::= Int "ether" [collateralUnit]
+ // -------------------------------------------
+    rule N ether => N *Int 1000000000 [macro]
 ```
 
 Base Data

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -73,8 +73,8 @@ Using `transact` triggers authorization checks (top-level calls should be done w
           Getting stuck is convenient for detecting bugs in tests.
 
 ```k
-    syntax MCDStep ::= "transact" Address MCDStep
- // ---------------------------------------------
+    syntax AdminStep ::= "transact" Address MCDStep
+ // -----------------------------------------------
     rule <k> transact ADDR:Address MCD:MCDStep => pushState ~> call MCD ~> dropState ... </k>
          <this> _ => ADDR </this>
          <msg-sender> _ => ADDR </msg-sender>
@@ -95,8 +95,8 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
     syntax CallFrame ::= frame(prevSender: Address, prevEvents: List, continuation: K)
  // ----------------------------------------------------------------------------------
 
-    syntax MCDStep ::= "call" MCDStep
- // ---------------------------------
+    syntax AdminStep ::= "call" MCDStep
+ // -----------------------------------
     rule <k> call MCD:MCDStep ~> CONT => MCD </k>
          <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => address(contract(MCD)) </this>
@@ -119,10 +119,9 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
          <events> L => L EVENTS </events>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
-    syntax MCDStep ::= MCDExceptionStep
-    syntax MCDExceptionStep ::= "exception" MCDStep
- // -----------------------------------------------
-    rule <k> MCDSTEP:MCDStep => exception MCDSTEP ... </k> requires notBool isMCDExceptionStep(MCDSTEP) [owise]
+    syntax AdminStep ::= "exception" MCDStep
+ // ----------------------------------------
+    rule <k> MCDSTEP:MCDStep => exception MCDSTEP ... </k> requires notBool isAdminStep(MCDSTEP) [owise]
 
     rule <k> exception E ~> _ => exception E ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -37,12 +37,20 @@ MCD Simulations
     rule <k> MCD:MCDStep MCDS:MCDSteps => MCD ~> MCDS ... </k>
 
     syntax MCDContract ::= contract(MCDStep) [function]
-    syntax Address ::= address(MCDContract) [function]
  // ---------------------------------------------------
 ```
 
 Authorization Scheme
 --------------------
+
+`Address` is a unique identifier of an account on the network.
+They can be either an `Int` or a `String` (for readability).
+In addition, each `MCDContract` is automatically an `Address`, under the assumption that there is a unique live instance of each one at a time.
+
+```k
+    syntax Address ::= Int | String | MCDContract
+ // ---------------------------------------------
+```
 
 Authorization happens at the `call` boundaries, which includes both transactions and calls between MCD contracts.
 Each contract must defined the `authorized` function, which returns the set of accounts which are authorized for that account.
@@ -103,7 +111,7 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
  // -----------------------------------
     rule <k> call MCD:MCDStep ~> CONT => MCD </k>
          <msg-sender> MSGSENDER => THIS </msg-sender>
-         <this> THIS => address(contract(MCD)) </this>
+         <this> THIS => contract(MCD) </this>
          <call-stack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </call-stack>
          <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires isAuthStep(MCD) impliesBool isAuthorized(THIS, contract(MCD))
@@ -181,20 +189,6 @@ We model everything with arbitrary precision rationals, but use sort information
 
     syntax MaybeWad ::= Wad | ".Wad"
  // --------------------------------
-```
-
-### Account addresses
-
--   `Address`: unique identifier of an account on the network, an `Int` in real life, but `String` here for readability.
-
-```k
-    syntax Address ::= Int | String
- // -------------------------------
-
-    syntax String ::= Address2String ( Address ) [function]
- // -------------------------------------------------------
-    rule Address2String ( I:Int    ) => Int2String(I)
-    rule Address2String ( S:String ) => S
 ```
 
 ### Time Increments

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -69,6 +69,10 @@ By default it's assumed that the special `ADMIN` account is authorized on all ot
     syntax AuthStep
     syntax MCDStep ::= AuthStep
  // ---------------------------
+
+    syntax WardStep ::= "rely" Address
+                      | "deny" Address
+ // ----------------------------------
 ```
 
 Transactions

--- a/kmcd.md
+++ b/kmcd.md
@@ -70,14 +70,14 @@ State Storage/Revert Semantics
 ```k
     rule <k> pushState => . ... </k>
          <kmcd-state> STATE </kmcd-state>
-         <preState> _ => <kmcd-state> STATE </kmcd-state> </preState>
+         <pre-state> _ => <kmcd-state> STATE </kmcd-state> </pre-state>
 
     rule <k> dropState => . ... </k>
-         <preState> _ => .K </preState>
+         <pre-state> _ => .K </pre-state>
 
     rule <k> popState => . ... </k>
          (_:KmcdStateCell => <kmcd-state> STATE </kmcd-state>)
-         <preState> <kmcd-state> STATE </kmcd-state> </preState>
+         <pre-state> <kmcd-state> STATE </kmcd-state> </pre-state>
 ```
 
 ```k

--- a/kmcd.md
+++ b/kmcd.md
@@ -54,7 +54,6 @@ module KMCD
           <flips/>
           <flop-state/>
           <gems/>
-          <join-state/>
           <jug/>
           <pot/>
           <spot/>

--- a/kmcd.md
+++ b/kmcd.md
@@ -54,6 +54,7 @@ module KMCD
           <flips/>
           <flop-state/>
           <gems/>
+          <join-state/>
           <jug/>
           <pot/>
           <spot/>

--- a/pot.md
+++ b/pot.md
@@ -13,7 +13,6 @@ Pot Configuration
 ```k
     configuration
       <pot>
-        <pot-addr> 0:Address </pot-addr>
         <pot-pies> .Map      </pot-pies> // mapping (address => uint256) Address |-> Wad
         <pot-pie>  0:Wad     </pot-pie>
         <pot-dsr>  1:Ray     </pot-dsr>
@@ -30,7 +29,7 @@ Pot Configuration
     syntax MCDStep ::= PotContract "." PotStep [klabel(potStep)]
  // ------------------------------------------------------------
     rule contract(Pot . _) => Pot
-    rule [[ address(Pot) => ADDR ]] <pot-addr> ADDR </pot-addr>
+    rule address(Pot) => "POT"
 
     syntax PotStep ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]

--- a/pot.md
+++ b/pot.md
@@ -13,13 +13,14 @@ Pot Configuration
 ```k
     configuration
       <pot>
-        <pot-pies> .Map      </pot-pies> // mapping (address => uint256) Address |-> Wad
-        <pot-pie>  0:Wad     </pot-pie>
-        <pot-dsr>  1:Ray     </pot-dsr>
-        <pot-chi>  1:Rat     </pot-chi> // arbitrary precision
-        <pot-vow>  0:Address </pot-vow>
-        <pot-rho>  0         </pot-rho>
-        <pot-live> true      </pot-live>
+        <pot-wards> .Set      </pot-wards>
+        <pot-pies>  .Map      </pot-pies> // mapping (address => uint256) Address |-> Wad
+        <pot-pie>   0:Wad     </pot-pie>
+        <pot-dsr>   1:Ray     </pot-dsr>
+        <pot-chi>   1:Rat     </pot-chi> // arbitrary precision
+        <pot-vow>   0:Address </pot-vow>
+        <pot-rho>   0         </pot-rho>
+        <pot-live>  true      </pot-live>
       </pot>
 ```
 
@@ -30,6 +31,7 @@ Pot Configuration
  // ------------------------------------------------------------
     rule contract(Pot . _) => Pot
     rule address(Pot) => "POT"
+    rule [[ wards(Pot) => WARDS ]] <pot-wards> WARDS </pot-wards>
 
     syntax PotStep ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]

--- a/pot.md
+++ b/pot.md
@@ -30,7 +30,6 @@ Pot Configuration
     syntax MCDStep ::= PotContract "." PotStep [klabel(potStep)]
  // ------------------------------------------------------------
     rule contract(Pot . _) => Pot
-    rule address(Pot) => "POT"
 ```
 
 Pot Authorization

--- a/pot.md
+++ b/pot.md
@@ -31,11 +31,24 @@ Pot Configuration
  // ------------------------------------------------------------
     rule contract(Pot . _) => Pot
     rule address(Pot) => "POT"
-    rule [[ wards(Pot) => WARDS ]] <pot-wards> WARDS </pot-wards>
+```
 
-    syntax PotStep ::= PotAuthStep
+Pot Authorization
+-----------------
+
+```k
+    syntax PotStep  ::= PotAuthStep
     syntax AuthStep ::= PotContract "." PotAuthStep [klabel(potStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Pot) => WARDS ]] <pot-wards> WARDS </pot-wards>
+
+    syntax PotAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Pot . rely ADDR => . ... </k>
+         <pot-wards> ... (.Set => SetItem(ADDR)) </pot-wards>
+
+    rule <k> Pot . deny ADDR => . ... </k>
+         <pot-wards> WARDS => WARDS -Set SetItem(ADDR) </pot-wards>
 ```
 
 File-able Fields

--- a/pot.md
+++ b/pot.md
@@ -69,7 +69,7 @@ Pot Semantics
  // -------------------------
     rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rat CHI *Rat ( DSR ^Rat (NOW -Int RHO) -Rat 1 ) ) ... </k>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <pot-chi> CHI => CHI *Rat DSR ^Rat (NOW -Int RHO) </pot-chi>
          <pot-rho> RHO => NOW </pot-rho>
          <pot-dsr> DSR </pot-dsr>
@@ -82,7 +82,7 @@ Pot Semantics
  // -----------------------------
     rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( CHI *Rat WAD ) ... </k>
          <this> THIS </this>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <msg-sender> MSGSENDER </msg-sender>
          <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE +Rat WAD ) ... </pot-pies>
          <pot-pie> PIE => PIE +Rat WAD </pot-pie>

--- a/spot.md
+++ b/spot.md
@@ -55,9 +55,7 @@ These parameters are controlled by governance/oracles:
 
 -   `pip`: next price to give from price feed.
 -   `mat`: liquidation ratio for a given ilk.
--   `par`: **TODO** it's unclear.
-    Wiki page says "relationship between Dai and 1 unit of value in the price. (Similar to TRFM.)", but that would seem to require storing one `par` per ilk.
-    Perhaps this means "actual price of Dai?", as in "how off-stable is Dai"?
+-   `par`: reference number for 1 Dai, used to scale target value of a single Dai (newer version of Target Rate Feedback Mechanism).
 
 ```k
     syntax SpotAuthStep ::= "file" SpotFile

--- a/spot.md
+++ b/spot.md
@@ -13,8 +13,9 @@ Spot Configuration
 ```k
     configuration
       <spot>
-        <spot-ilks> .Map  </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
-        <spot-par>  0:Ray </spot-par>
+        <spot-wards> .Set  </spot-wards>
+        <spot-ilks>  .Map  </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
+        <spot-par>   0:Ray </spot-par>
       </spot>
 ```
 
@@ -25,6 +26,7 @@ Spot Configuration
  // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
     rule address(Spot) => "SPOT"
+    rule [[ wards(Spot) => WARDS ]] <spot-wards> WARDS </spot-wards>
 
     syntax SpotAuthStep
     syntax SpotStep ::= SpotAuthStep

--- a/spot.md
+++ b/spot.md
@@ -26,12 +26,24 @@ Spot Configuration
  // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
     rule address(Spot) => "SPOT"
-    rule [[ wards(Spot) => WARDS ]] <spot-wards> WARDS </spot-wards>
+```
 
-    syntax SpotAuthStep
+Spot Authorization
+------------------
+
+```k
     syntax SpotStep ::= SpotAuthStep
     syntax AuthStep ::= SpotContract "." SpotAuthStep [klabel(spotStep)]
  // --------------------------------------------------------------------
+    rule [[ wards(Spot) => WARDS ]] <spot-wards> WARDS </spot-wards>
+
+    syntax SpotAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Spot . rely ADDR => . ... </k>
+         <spot-wards> ... (.Set => SetItem(ADDR)) </spot-wards>
+
+    rule <k> Spot . deny ADDR => . ... </k>
+         <spot-wards> WARDS => WARDS -Set SetItem(ADDR) </spot-wards>
 ```
 
 Spot Data

--- a/spot.md
+++ b/spot.md
@@ -13,9 +13,8 @@ Spot Configuration
 ```k
     configuration
       <spot>
-        <spot-addr> 0:Address </spot-addr>
-        <spot-ilks> .Map      </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
-        <spot-par>  0:Ray     </spot-par>
+        <spot-ilks> .Map  </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
+        <spot-par>  0:Ray </spot-par>
       </spot>
 ```
 
@@ -25,7 +24,7 @@ Spot Configuration
     syntax MCDStep ::= SpotContract "." SpotStep [klabel(spotStep)]
  // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
-    rule [[ address(Spot) => ADDR ]] <spot-addr> ADDR </spot-addr>
+    rule address(Spot) => "SPOT"
 
     syntax SpotAuthStep
     syntax SpotStep ::= SpotAuthStep

--- a/spot.md
+++ b/spot.md
@@ -25,7 +25,6 @@ Spot Configuration
     syntax MCDStep ::= SpotContract "." SpotStep [klabel(spotStep)]
  // ---------------------------------------------------------------
     rule contract(Spot . _) => Spot
-    rule address(Spot) => "SPOT"
 ```
 
 Spot Authorization

--- a/vat.md
+++ b/vat.md
@@ -11,17 +11,16 @@ Vat Configuration
 ```k
     configuration
       <vat>
-        <vat-addr> 0:Address </vat-addr>
-        <vat-can>  .Map      </vat-can>  // mapping (address (address => uint))       Address |-> Set
-        <vat-ilks> .Map      </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
-        <vat-urns> .Map      </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
-        <vat-gem>  .Map      </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
-        <vat-dai>  .Map      </vat-dai>  // mapping (address => uint256)              Address |-> Rad
-        <vat-sin>  .Map      </vat-sin>  // mapping (address => uint256)              Address |-> Rad
-        <vat-debt> 0:Rad     </vat-debt> // Total Dai Issued
-        <vat-vice> 0:Rad     </vat-vice> // Total Unbacked Dai
-        <vat-Line> 0:Rad     </vat-Line> // Total Debt Ceiling
-        <vat-live> true      </vat-live> // Access Flag
+        <vat-can>  .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
+        <vat-ilks> .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
+        <vat-urns> .Map  </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
+        <vat-gem>  .Map  </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
+        <vat-dai>  .Map  </vat-dai>  // mapping (address => uint256)              Address |-> Rad
+        <vat-sin>  .Map  </vat-sin>  // mapping (address => uint256)              Address |-> Rad
+        <vat-debt> 0:Rad </vat-debt> // Total Dai Issued
+        <vat-vice> 0:Rad </vat-vice> // Total Unbacked Dai
+        <vat-Line> 0:Rad </vat-Line> // Total Debt Ceiling
+        <vat-live> true  </vat-live> // Access Flag
       </vat>
 ```
 
@@ -47,7 +46,7 @@ For convenience, total Dai/Sin are tracked:
     syntax MCDStep ::= VatContract "." VatStep [klabel(vatStep)]
  // ------------------------------------------------------------
     rule contract(Vat . _) => Vat
-    rule [[ address(Vat) => ADDR ]] <vat-addr> ADDR </vat-addr>
+    rule address(Vat) => "VAT"
 
     syntax VatStep ::= VatAuthStep
     syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]

--- a/vat.md
+++ b/vat.md
@@ -11,16 +11,17 @@ Vat Configuration
 ```k
     configuration
       <vat>
-        <vat-can>  .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
-        <vat-ilks> .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
-        <vat-urns> .Map  </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
-        <vat-gem>  .Map  </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
-        <vat-dai>  .Map  </vat-dai>  // mapping (address => uint256)              Address |-> Rad
-        <vat-sin>  .Map  </vat-sin>  // mapping (address => uint256)              Address |-> Rad
-        <vat-debt> 0:Rad </vat-debt> // Total Dai Issued
-        <vat-vice> 0:Rad </vat-vice> // Total Unbacked Dai
-        <vat-Line> 0:Rad </vat-Line> // Total Debt Ceiling
-        <vat-live> true  </vat-live> // Access Flag
+        <vat-wards> .Set  </vat-wards>
+        <vat-can>   .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
+        <vat-ilks>  .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
+        <vat-urns>  .Map  </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
+        <vat-gem>   .Map  </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
+        <vat-dai>   .Map  </vat-dai>  // mapping (address => uint256)              Address |-> Rad
+        <vat-sin>   .Map  </vat-sin>  // mapping (address => uint256)              Address |-> Rad
+        <vat-debt>  0:Rad </vat-debt> // Total Dai Issued
+        <vat-vice>  0:Rad </vat-vice> // Total Unbacked Dai
+        <vat-Line>  0:Rad </vat-Line> // Total Debt Ceiling
+        <vat-live>  true  </vat-live> // Access Flag
       </vat>
 ```
 
@@ -47,6 +48,7 @@ For convenience, total Dai/Sin are tracked:
  // ------------------------------------------------------------
     rule contract(Vat . _) => Vat
     rule address(Vat) => "VAT"
+    rule [[ wards(Vat) => WARDS ]] <vat-wards> WARDS </vat-wards>
 
     syntax VatStep ::= VatAuthStep
     syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]

--- a/vat.md
+++ b/vat.md
@@ -48,11 +48,24 @@ For convenience, total Dai/Sin are tracked:
  // ------------------------------------------------------------
     rule contract(Vat . _) => Vat
     rule address(Vat) => "VAT"
-    rule [[ wards(Vat) => WARDS ]] <vat-wards> WARDS </vat-wards>
+```
 
-    syntax VatStep ::= VatAuthStep
+Vat Authorization
+-----------------
+
+```k
+    syntax VatStep  ::= VatAuthStep
     syntax AuthStep ::= VatContract "." VatAuthStep [klabel(vatStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Vat) => WARDS ]] <vat-wards> WARDS </vat-wards>
+
+    syntax VatAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Vat . rely ADDR => . ... </k>
+         <vat-wards> ... (.Set => SetItem(ADDR)) </vat-wards>
+
+    rule <k> Vat . deny ADDR => . ... </k>
+         <vat-wards> WARDS => WARDS -Set SetItem(ADDR) </vat-wards>
 ```
 
 CDP Data

--- a/vat.md
+++ b/vat.md
@@ -47,7 +47,6 @@ For convenience, total Dai/Sin are tracked:
     syntax MCDStep ::= VatContract "." VatStep [klabel(vatStep)]
  // ------------------------------------------------------------
     rule contract(Vat . _) => Vat
-    rule address(Vat) => "VAT"
 ```
 
 Vat Authorization

--- a/vow.md
+++ b/vow.md
@@ -17,15 +17,16 @@ Vow Configuration
 ```k
     configuration
       <vow>
-        <vow-sins> .Map  </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
-        <vow-sin>  0:Rad </vow-sin>
-        <vow-ash>  0:Rad </vow-ash>
-        <vow-wait> 0     </vow-wait>
-        <vow-dump> 0:Wad </vow-dump>
-        <vow-sump> 0:Rad </vow-sump>
-        <vow-bump> 0:Rad </vow-bump>
-        <vow-hump> 0:Rad </vow-hump>
-        <vow-live> true  </vow-live>
+        <vow-wards> .Set  </vow-wards>
+        <vow-sins>  .Map  </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
+        <vow-sin>   0:Rad </vow-sin>
+        <vow-ash>   0:Rad </vow-ash>
+        <vow-wait>  0     </vow-wait>
+        <vow-dump>  0:Wad </vow-dump>
+        <vow-sump>  0:Rad </vow-sump>
+        <vow-bump>  0:Rad </vow-bump>
+        <vow-hump>  0:Rad </vow-hump>
+        <vow-live>  true  </vow-live>
       </vow>
 ```
 
@@ -36,6 +37,7 @@ Vow Configuration
  // ------------------------------------------------------------
     rule contract(Vow . _) => Vow
     rule address(Vow) => "VOW"
+    rule [[ wards(Vow) => WARDS ]] <vow-wards> WARDS </vow-wards>
 
     syntax VowStep ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]

--- a/vow.md
+++ b/vow.md
@@ -87,7 +87,7 @@ Vow Semantics
     syntax VowAuthStep ::= "fess" Rad
  // ---------------------------------
     rule <k> Vow . fess TAB => . ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <vow-sins>
            ...
            NOW |-> (SIN' => SIN' +Rat TAB)
@@ -98,7 +98,7 @@ Vow Semantics
     syntax VowStep ::= "flog" Int
  // -----------------------------
     rule <k> Vow . flog ERA => . ... </k>
-         <currentTime> NOW </currentTime>
+         <current-time> NOW </current-time>
          <vow-wait> WAIT </vow-wait>
          <vow-sins>... ERA |-> (SIN' => 0) </vow-sins>
          <vow-sin> SIN => SIN -Rat SIN' </vow-sin>

--- a/vow.md
+++ b/vow.md
@@ -17,16 +17,15 @@ Vow Configuration
 ```k
     configuration
       <vow>
-        <vow-addr> 0:Address </vow-addr>
-        <vow-sins> .Map      </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
-        <vow-sin>  0:Rad     </vow-sin>
-        <vow-ash>  0:Rad     </vow-ash>
-        <vow-wait> 0         </vow-wait>
-        <vow-dump> 0:Wad     </vow-dump>
-        <vow-sump> 0:Rad     </vow-sump>
-        <vow-bump> 0:Rad     </vow-bump>
-        <vow-hump> 0:Rad     </vow-hump>
-        <vow-live> true      </vow-live>
+        <vow-sins> .Map  </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
+        <vow-sin>  0:Rad </vow-sin>
+        <vow-ash>  0:Rad </vow-ash>
+        <vow-wait> 0     </vow-wait>
+        <vow-dump> 0:Wad </vow-dump>
+        <vow-sump> 0:Rad </vow-sump>
+        <vow-bump> 0:Rad </vow-bump>
+        <vow-hump> 0:Rad </vow-hump>
+        <vow-live> true  </vow-live>
       </vow>
 ```
 
@@ -36,7 +35,7 @@ Vow Configuration
     syntax MCDStep ::= VowContract "." VowStep [klabel(vowStep)]
  // ------------------------------------------------------------
     rule contract(Vow . _) => Vow
-    rule [[ address(Vow) => ADDR ]] <vow-addr> ADDR </vow-addr>
+    rule address(Vow) => "VOW"
 
     syntax VowStep ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]

--- a/vow.md
+++ b/vow.md
@@ -37,11 +37,24 @@ Vow Configuration
  // ------------------------------------------------------------
     rule contract(Vow . _) => Vow
     rule address(Vow) => "VOW"
-    rule [[ wards(Vow) => WARDS ]] <vow-wards> WARDS </vow-wards>
+```
 
-    syntax VowStep ::= VowAuthStep
+Vow Authorization
+-----------------
+
+```k
+    syntax VowStep  ::= VowAuthStep
     syntax AuthStep ::= VowContract "." VowAuthStep [klabel(vowStep)]
  // -----------------------------------------------------------------
+    rule [[ wards(Vow) => WARDS ]] <vow-wards> WARDS </vow-wards>
+
+    syntax VowAuthStep ::= WardStep
+ // -------------------------------
+    rule <k> Vow . rely ADDR => . ... </k>
+         <vow-wards> ... (.Set => SetItem(ADDR)) </vow-wards>
+
+    rule <k> Vow . deny ADDR => . ... </k>
+         <vow-wards> WARDS => WARDS -Set SetItem(ADDR) </vow-wards>
 ```
 
 File-able Data

--- a/vow.md
+++ b/vow.md
@@ -36,7 +36,6 @@ Vow Configuration
     syntax MCDStep ::= VowContract "." VowStep [klabel(vowStep)]
  // ------------------------------------------------------------
     rule contract(Vow . _) => Vow
-    rule address(Vow) => "VOW"
 ```
 
 Vow Authorization
@@ -213,7 +212,7 @@ Vow Semantics
          <vat-dai>
            ...
            THIS |-> DAI
-           address(Flap) |-> FLAPDAI
+           Flap |-> FLAPDAI
            ...
          </vat-dai>
          <vow-live> _ => false </vow-live>


### PR DESCRIPTION
-   Renames some cells to use `-` instead of camel-case (for consistency).
-   Removes the `<*-addr>` cells, which are largely unused.
-   Checks for authorization by looking for containment in the added `<*-wards>` cells at the `call` boundaries.
-   Uses sort `AdminStep` for all steps which `exception` shouldn't pass through (eg. the next transaction).