### PR TITLE
Attack test: lucash-pot-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.build
+/tests/*/*.out

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,13 @@ pipeline {
             '''
           }
         }
+        stage('Run Simulation Tests') {
+          steps {
+            sh '''
+              make test-execution -j8
+            '''
+          }
+        }
       }
     }
     stage('Deploy') {

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ LUA_PATH:=$(PANDOC_TANGLE_SUBMODULE)/?.lua;;
 export TANGLER
 export LUA_PATH
 
-.PHONY: all clean                                 \
-        deps deps-k deps-tangle deps-media        \
-        defn defn-llvm defn-haskell               \
-        build build-llvm build-haskell build-java \
-        test test-python-config test-python-run
+.PHONY: all clean                                              \
+        deps deps-k deps-tangle deps-media                     \
+        defn defn-llvm defn-haskell                            \
+        build build-llvm build-haskell build-java              \
+        test test-python-config test-python-run test-execution
 .SECONDARY:
 
 all: build
@@ -144,7 +144,9 @@ $(java_kompiled): $(java_files)
 # Test
 # ----
 
-test: test-python-config test-python-run
+test: test-python-config test-python-run test-execution
+
+### `pyk` tests
 
 test-python-config:
 	./mcd-pyk.py
@@ -152,3 +154,16 @@ test-python-config:
 test-python-run: tests/sneak-tx.json
 	./mcd-pyk.py $<
 
+### Execution tests
+
+TEST_BACKEND := llvm
+KMCD         := ./kmcd
+CHECK        := git --no-pager diff --no-index
+
+tests/%.mcd.run: tests/%.mcd
+	$(KMCD) run --backend $(TEST_BACKEND) $< > $<.out
+	$(CHECK) $<.expected $<.out
+
+execution_tests := $(wildcard tests/*/*.mcd)
+
+test-execution: $(execution_tests:=.run)

--- a/end.md
+++ b/end.md
@@ -85,6 +85,22 @@ These parameters are controlled by governance:
 
 **NOTE**: We have not added `file` steps for `vat`, `cat`, `vow`, `pot`, or `spot` because this model does not deal with swapping out implementations.
 
+End Initialization
+------------------
+
+Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
+
+-   `initGap`: Initialize the gap for a given ilk to 0.
+    **TODO**: Should `End . initGap ILKID` happen directly when `End . cage ILKID` happens?
+
+```k
+    syntax EndAuthStep ::= "initGap" String
+ // ---------------------------------------
+    rule <k> End . initGap ILKID => . ... </k>
+         <end-gap> GAPS => GAPS [ ILKID <- 0 ] </end-gap>
+      requires notBool ILKID in_keys(GAPS)
+```
+
 End Semantics
 -------------
 

--- a/end.md
+++ b/end.md
@@ -95,7 +95,9 @@ End Semantics
           => call Vat . cage
           ~> call Cat . cage
           ~> call Vow . cage
-          ~> call Pot . cage ... </k>
+          ~> call Pot . cage
+         ...
+         </k>
          <current-time> NOW </current-time>
          <end-live> true => false </end-live>
          <end-when> _ => NOW </end-when>

--- a/end.md
+++ b/end.md
@@ -195,7 +195,7 @@ End Semantics
 
     syntax EndStep ::= "thaw"
  // -------------------------
-    rule <k> End . thaw ... </k>
+    rule <k> End . thaw => . ... </k>
          <current-time> NOW </current-time>
          <end-live> false </end-live>
          <end-debt> 0 => DEBT </end-debt>

--- a/gem.md
+++ b/gem.md
@@ -53,6 +53,30 @@ Gem Authorization
          </gem>
 ```
 
+Gem Initialization
+------------------
+
+Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
+
+-   `init`: Creates the blank contract data for a new gem of a given ilk.
+-   `initUser`: Creates a new account for a given user in a given ilk.
+
+```k
+    syntax GemAuthStep ::= "init"
+                         | "initUser" Address
+ // -----------------------------------------
+    rule <k> Gem GEMID . init => . ... </k>
+         <gems> ... ( .Bag => <gem> <gem-id> GEMID </gem-id> ... </gem> ) ... </gems>
+
+    rule <k> Gem GEMID . initUser ADDR => . ... </k>
+         <gem>
+            <gem-id> GEMID </gem-id>
+            <gem-balances> BALS => BALS [ ADDR <- 0 ] </gem-balances>
+            ...
+         </gem>
+      requires notBool ADDR in_keys(BALS)
+```
+
 Gem Semantics
 -------------
 

--- a/join.md
+++ b/join.md
@@ -82,6 +82,19 @@ Join Authorization
          <dai-join-wards> WARDS => WARDS -Set SetItem(ADDR) </dai-join-wards>
 ```
 
+Join Initialization
+-------------------
+
+Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
+
+-   `init`: Creates the joins account in the given gem for users to join their collateral to.
+
+```k
+    syntax GemJoinAuthStep ::= "init"
+ // ---------------------------------
+    rule <k> GemJoin GEMID . init => Gem GEMID . initUser GemJoin GEMID ... </k>
+```
+
 Join Semantics
 --------------
 

--- a/jug.md
+++ b/jug.md
@@ -77,7 +77,9 @@ These parameters are controlled by governance:
                      | "vow-file" Address
  // -------------------------------------
     rule <k> Jug . file duty ILKID DUTY => . ... </k>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) ) ... </jug-ilks>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) , rho: RHO ) ... </jug-ilks>
+         <current-time> NOW </current-time>
+      requires NOW ==Int RHO
 
     rule <k> Jug . file base BASE => . ... </k>
          <jug-base> _ => BASE </jug-base>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -198,9 +198,12 @@ We simulate that here.
 
 ```k
     syntax MCDStep ::= "TimeStep"
- // -----------------------------
-    rule <k> TimeStep => . ... </k>
-         <current-time> TIME => TIME +Int 1 second </current-time>
+                     | "TimeStep" Int
+ // ---------------------------------
+    rule <k> TimeStep => TimeStep 1 ... </k>
+
+    rule <k> TimeStep N => . ... </k>
+         <current-time> TIME => TIME +Int N </current-time>
 
     syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
  // --------------------------------------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -204,6 +204,7 @@ We simulate that here.
 
     rule <k> TimeStep N => . ... </k>
          <current-time> TIME => TIME +Int N </current-time>
+      requires N >Int 0
 
     syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
  // --------------------------------------------------------

--- a/pot.md
+++ b/pot.md
@@ -78,6 +78,21 @@ These parameters are controlled by governance:
 
 **TODO**: Need to use `vow-file` as name to avoid conflict with `<vow>` cell.
 
+Pot Initialization
+------------------
+
+Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
+
+-   `initUser`: Add the given users accounts to the pies.
+
+```k
+    syntax PotAuthStep ::= "initUser" Address
+ // -----------------------------------------
+    rule <k> Pot . initUser ADDR => . ... </k>
+         <pot-pies> PIES => PIES [ ADDR <- 0 ] </pot-pies>
+      requires notBool ADDR in_keys(PIES)
+```
+
 Pot Semantics
 -------------
 

--- a/pot.md
+++ b/pot.md
@@ -83,7 +83,7 @@ Pot Initialization
 
 Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
 
--   `initUser`: Add the given users accounts to the pies.
+-   `initUser`: Add the given user's account to the pies.
 
 ```k
     syntax PotAuthStep ::= "initUser" Address

--- a/pot.md
+++ b/pot.md
@@ -67,6 +67,10 @@ These parameters are controlled by governance:
  // -------------------------------------
     rule <k> Pot . file dsr DSR => . ... </k>
          <pot-dsr> _ => DSR </pot-dsr>
+         <pot-rho> RHO </pot-rho>
+         <current-time> NOW </current-time>
+         <pot-live> true </pot-live>
+      requires NOW ==Int RHO
 
     rule <k> Pot . file vow-file ADDR => . ... </k>
          <pot-vow> _ => ADDR </pot-vow>

--- a/pot.md
+++ b/pot.md
@@ -87,7 +87,7 @@ Pot Semantics
     rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rat CHI *Rat ( DSR ^Rat (NOW -Int RHO) -Rat 1 ) ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
-         <pot-chi> CHI => CHI *Rat DSR ^Rat (NOW -Int RHO) </pot-chi>
+         <pot-chi> CHI => CHI *Rat (DSR ^Rat (NOW -Int RHO)) </pot-chi>
          <pot-rho> RHO => NOW </pot-rho>
          <pot-dsr> DSR </pot-dsr>
          <pot-vow> VOW </pot-vow>

--- a/spot.md
+++ b/spot.md
@@ -15,7 +15,7 @@ Spot Configuration
       <spot>
         <spot-wards> .Set  </spot-wards>
         <spot-ilks>  .Map  </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
-        <spot-par>   0:Ray </spot-par>
+        <spot-par>   1:Ray </spot-par>
       </spot>
 ```
 

--- a/spot.md
+++ b/spot.md
@@ -97,6 +97,26 @@ Spot Events
  // ---------------------------------------
 ```
 
+Spot Initialization
+-------------------
+
+Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
+
+-   `init`: Initialize the spotter for a given ilk.
+-   `setPrice`: Manually inject a value for the price feed of a given ilk.
+
+```k
+    syntax SpotAuthStep ::= "init"     String
+                          | "setPrice" String Wad
+ // ---------------------------------------------
+    rule <k> Spot . init ILKID => . ... </k>
+         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad , mat: 1 ) ] </spot-ilks>
+      requires notBool ILKID in_keys(ILKS)
+
+    rule <k> Spot . setPrice ILKID PRICE => . ... </k>
+         <spot-ilks> ... ILKID |-> SpotIlk( ... pip: (_ => PRICE) ) ... </spot-ilks>
+```
+
 Spot Semantics
 --------------
 

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -1,24 +1,33 @@
-// Initial reliances between contracts
+// MCD Internal Contract Setup
+// ---------------------------
+
+// Auhthorize Pot/End for Vat
 transact ADMIN Vat . rely Pot
 transact ADMIN Vat . rely End
 
-// Initialize Vow, Flap, End addresses for Vat.
+// Authorize End for Cat/Vow/Pot
+transact ADMIN Cat . rely End
+transact ADMIN Vow . rely End
+transact ADMIN Pot . rely End
+
+// Authorize Vow for Flap/Flop
+transact ADMIN Flap . rely Vow
+transact ADMIN Flop . rely Vow
+
+// Initialize Vat accounts for Vow/Pot/Flap/End
 transact ADMIN Vat . initUser Vow
 transact ADMIN Vat . initUser Pot
 transact ADMIN Vat . initUser Flap
 transact ADMIN Vat . initUser End
 
-transact ADMIN Cat  . rely End
-transact ADMIN Vow  . rely End
-transact ADMIN Flap . rely Vow
-transact ADMIN Flop . rely Vow
+// File Vow contract for Pot (since Pot doesn't depend on Vow?)
+transact ADMIN Pot . file vow-file Vow
 
-// Initialize gold Gem and GemJoin
+// Collateral Setup
+// ----------------
+
+// "gold" collateral and joiner
 transact ADMIN Gem "gold" . init
-transact ADMIN Gem "gold" . initUser "Alice"
-transact ADMIN Gem "gold" . initUser "Bobby"
-transact ADMIN Gem "gold" . mint "Alice" 10
-transact ADMIN Gem "gold" . mint "Bobby" 10
 transact ADMIN GemJoin "gold" . init
 
 // Allow GemJoin "gold" to call into Vat
@@ -29,16 +38,24 @@ transact ADMIN Vat . initGem "gold" End
 transact ADMIN Spot . init     "gold"
 transact ADMIN Spot . setPrice "gold" 1
 
-// Initialize Pot
-transact ADMIN Pot . file vow-file Vow
-transact ADMIN Pot . initUser "Alice"
-transact ADMIN Pot . initUser "Bobby"
-
 // Initialize Vat, both total Line and gold parameters
 transact ADMIN Vat . file Line 1000 ether
 transact ADMIN Vat . initIlk "gold"
 transact ADMIN Vat . file spot "gold" 3 ether
 transact ADMIN Vat . file line "gold" 1000 ether
+
+// User Setup
+// ----------
+
+// Initialize gold Gem and GemJoin
+transact ADMIN Gem "gold" . initUser "Alice"
+transact ADMIN Gem "gold" . initUser "Bobby"
+transact ADMIN Gem "gold" . mint "Alice" 10
+transact ADMIN Gem "gold" . mint "Bobby" 10
+
+// Initialize Pot
+transact ADMIN Pot . initUser "Alice"
+transact ADMIN Pot . initUser "Bobby"
 
 // Initialize users Alice and Bob with gold Gem
 transact ADMIN Vat . initUser "Alice"
@@ -57,7 +74,9 @@ transact "Bobby" GemJoin "gold" . join "Bobby" 10
 transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" 10 10
 transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10
 
-// Attack sequence
+// Attack Sequence
+// ---------------
+
 transact ADMIN End . cage
 transact ADMIN End . cage "gold"
 transact ADMIN End . initGap "gold"       // injected because no default setting of `gap` to 0
@@ -70,4 +89,5 @@ transact ADMIN Pot . file dsr 2
 TimeStep 1 second
 transact "Alice" Pot . drip
 transact "Alice" Pot . exit 10
+
 .MCDSteps

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -15,6 +15,10 @@ transact "Admin" Vat . initIlk "gold"
 transact "Admin" Vat . file spot "gold" 3 ether
 transact "Admin" Vat . file line "gold" 1000 ether
 
+// Initialize "VOW" and "FLAP" addresses for Vat.
+transact "Admin" Vat . initUser "VOW"
+transact "Admin" Vat . initUser "FLAP"
+
 // Initialize users Alice and Bob with gold Gem
 transact "Admin" Vat . initUser "Alice"
 transact "Admin" Vat . initUser "Bobby"

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -9,20 +9,29 @@ transact "Admin" Gem "gold" . mint "Alice" 10
 transact "Admin" Gem "gold" . mint "Bobby" 10
 transact "Admin" GemJoin "gold" . init
 
+// Initialize Spot for gold
+Spot . init     "gold"
+Spot . setPrice "gold" 5
+
 // Initialize Vat, both total Line and gold parameters
 transact "Admin" Vat . file Line 1000 ether
 transact "Admin" Vat . initIlk "gold"
 transact "Admin" Vat . file spot "gold" 3 ether
 transact "Admin" Vat . file line "gold" 1000 ether
 
-// Initialize "VOW" and "FLAP" addresses for Vat.
+// Initialize "VOW", "FLAP", "END" addresses for Vat.
 transact "Admin" Vat . initUser "VOW"
 transact "Admin" Vat . initUser "FLAP"
+transact "Admin" Vat . initUser "END"
+transact "Admin" Vat . initGem "gold" "END"
 
 // Initialize users Alice and Bob with gold Gem
 transact "Admin" Vat . initUser "Alice"
-transact "Admin" Vat . initUser "Bobby"
+transact "Admin" Vat . initGem "gold" "Alice"
 transact "Admin" Vat . initCDP "gold" "Alice"
+
+//transact "Admin" Vat . initUser "Bobby"
+transact "Admin" Vat . initGem "gold" "Bobby"
 transact "Admin" Vat . initCDP "gold" "Bobby"
 
 // Setup CDPs
@@ -34,9 +43,10 @@ transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10
 // Attack sequence
 transact "Admin" End . cage
 transact "Admin" End . cage "gold"
+transact "Admin" End . initGap "gold"       // injected because no default setting of `gap` to 0
 transact "Admin" End . skim "gold" "Alice"
 transact "Admin" End . skim "gold" "Bobby"
 transact "Admin" End . thaw
-transact "Admin" End . flow "gold"
-transact "Alice" Pot . drip
+//transact "Admin" End . flow "gold"
+//transact "Alice" Pot . drip
 .MCDSteps

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -1,0 +1,38 @@
+// Add an authorized account
+authorize "Admin"
+
+// Initialize gold Gem and GemJoin
+transact "Admin" Gem "gold" . init
+transact "Admin" Gem "gold" . initUser "Alice"
+transact "Admin" Gem "gold" . initUser "Bob"
+transact "Admin" Gem "gold" . mint "Alice" 10
+transact "Admin" Gem "gold" . mint "Bob"   10
+transact "Admin" GemJoin "gold" . init
+
+// Initialize Vat, both total Line and gold parameters
+transact "Admin" Vat . file Line 1000 ether
+transact "Admin" Vat . initIlk "gold"
+transact "Admin" Vat . file spot "gold" 3    ether
+transact "Admin" Vat . file line "gold" 1000 ether
+
+// Initialize users Alice and Bob with gold Gem
+transact "Admin" Vat . initUser "Alice"
+transact "Admin" Vat . initUser "Bob"
+transact "Admin" Vat . initCDP "gold" "Alice"
+transact "Admin" Vat . initCDP "gold" "Bob"
+
+// Setup CDPs
+transact "Alice" GemJoin "gold" . join "Alice" 10
+transact "Bob"   GemJoin "gold" . join "Bob"   10
+transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" 10 10
+transact "Bob"   Vat . frob "gold" "Bob"   "Bob"   "Bob"   10 10
+
+// Attack sequence
+transact "Admin" End . cage
+transact "Admin" End . cage "gold"
+transact "Admin" End . skim "gold" "Alice"
+transact "Admin" End . skim "gold" "Bob"
+transact "Admin" End . thaw
+transact "Admin" End . flow "gold"
+transact "Alice" Pot . drip
+.MCDSteps

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -10,8 +10,13 @@ transact "Admin" Gem "gold" . mint "Bobby" 10
 transact "Admin" GemJoin "gold" . init
 
 // Initialize Spot for gold
-Spot . init     "gold"
-Spot . setPrice "gold" 5
+transact "Admin" Spot . init     "gold"
+transact "Admin" Spot . setPrice "gold" 1
+
+// Initialize Pot
+transact "Admin" Pot . file vow-file "VOW"
+transact "Admin" Pot . initUser "Alice"
+transact "Admin" Pot . initUser "Bobby"
 
 // Initialize Vat, both total Line and gold parameters
 transact "Admin" Vat . file Line 1000 ether
@@ -21,6 +26,7 @@ transact "Admin" Vat . file line "gold" 1000 ether
 
 // Initialize "VOW", "FLAP", "END" addresses for Vat.
 transact "Admin" Vat . initUser "VOW"
+transact "Admin" Vat . initUser "POT"
 transact "Admin" Vat . initUser "FLAP"
 transact "Admin" Vat . initUser "END"
 transact "Admin" Vat . initGem "gold" "END"
@@ -29,10 +35,12 @@ transact "Admin" Vat . initGem "gold" "END"
 transact "Admin" Vat . initUser "Alice"
 transact "Admin" Vat . initGem "gold" "Alice"
 transact "Admin" Vat . initCDP "gold" "Alice"
+transact "Alice" Vat . hope "POT"
 
-//transact "Admin" Vat . initUser "Bobby"
+transact "Admin" Vat . initUser "Bobby"
 transact "Admin" Vat . initGem "gold" "Bobby"
 transact "Admin" Vat . initCDP "gold" "Bobby"
+transact "Bobby" Vat . hope "POT"
 
 // Setup CDPs
 transact "Alice" GemJoin "gold" . join "Alice" 10
@@ -47,6 +55,10 @@ transact "Admin" End . initGap "gold"       // injected because no default setti
 transact "Admin" End . skim "gold" "Alice"
 transact "Admin" End . skim "gold" "Bobby"
 transact "Admin" End . thaw
-//transact "Admin" End . flow "gold"
-//transact "Alice" Pot . drip
+transact "Admin" End . flow "gold"
+transact "Alice" Pot . join 10
+transact "Admin" Pot . file dsr 2
+TimeStep 1 second
+transact "Alice" Pot . drip
+transact "Alice" Pot . exit 10
 .MCDSteps

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -1,3 +1,18 @@
+// Initial reliances between contracts
+transact ADMIN Vat . rely Pot
+transact ADMIN Vat . rely End
+
+// Initialize Vow, Flap, End addresses for Vat.
+transact ADMIN Vat . initUser Vow
+transact ADMIN Vat . initUser Pot
+transact ADMIN Vat . initUser Flap
+transact ADMIN Vat . initUser End
+
+transact ADMIN Cat  . rely End
+transact ADMIN Vow  . rely End
+transact ADMIN Flap . rely Vow
+transact ADMIN Flop . rely Vow
+
 // Initialize gold Gem and GemJoin
 transact ADMIN Gem "gold" . init
 transact ADMIN Gem "gold" . initUser "Alice"
@@ -6,12 +21,16 @@ transact ADMIN Gem "gold" . mint "Alice" 10
 transact ADMIN Gem "gold" . mint "Bobby" 10
 transact ADMIN GemJoin "gold" . init
 
+// Allow GemJoin "gold" to call into Vat
+transact ADMIN Vat . rely GemJoin "gold"
+transact ADMIN Vat . initGem "gold" End
+
 // Initialize Spot for gold
 transact ADMIN Spot . init     "gold"
 transact ADMIN Spot . setPrice "gold" 1
 
 // Initialize Pot
-transact ADMIN Pot . file vow-file "VOW"
+transact ADMIN Pot . file vow-file Vow
 transact ADMIN Pot . initUser "Alice"
 transact ADMIN Pot . initUser "Bobby"
 
@@ -21,23 +40,16 @@ transact ADMIN Vat . initIlk "gold"
 transact ADMIN Vat . file spot "gold" 3 ether
 transact ADMIN Vat . file line "gold" 1000 ether
 
-// Initialize "VOW", "FLAP", "END" addresses for Vat.
-transact ADMIN Vat . initUser "VOW"
-transact ADMIN Vat . initUser "POT"
-transact ADMIN Vat . initUser "FLAP"
-transact ADMIN Vat . initUser "END"
-transact ADMIN Vat . initGem "gold" "END"
-
 // Initialize users Alice and Bob with gold Gem
 transact ADMIN Vat . initUser "Alice"
 transact ADMIN Vat . initGem "gold" "Alice"
 transact ADMIN Vat . initCDP "gold" "Alice"
-transact "Alice" Vat . hope "POT"
+transact "Alice" Vat . hope Pot
 
 transact ADMIN Vat . initUser "Bobby"
 transact ADMIN Vat . initGem "gold" "Bobby"
 transact ADMIN Vat . initCDP "gold" "Bobby"
-transact "Bobby" Vat . hope "POT"
+transact "Bobby" Vat . hope Pot
 
 // Setup CDPs
 transact "Alice" GemJoin "gold" . join "Alice" 10

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -1,45 +1,42 @@
-// Add an authorized account
-authorize "Admin"
-
 // Initialize gold Gem and GemJoin
-transact "Admin" Gem "gold" . init
-transact "Admin" Gem "gold" . initUser "Alice"
-transact "Admin" Gem "gold" . initUser "Bobby"
-transact "Admin" Gem "gold" . mint "Alice" 10
-transact "Admin" Gem "gold" . mint "Bobby" 10
-transact "Admin" GemJoin "gold" . init
+transact ADMIN Gem "gold" . init
+transact ADMIN Gem "gold" . initUser "Alice"
+transact ADMIN Gem "gold" . initUser "Bobby"
+transact ADMIN Gem "gold" . mint "Alice" 10
+transact ADMIN Gem "gold" . mint "Bobby" 10
+transact ADMIN GemJoin "gold" . init
 
 // Initialize Spot for gold
-transact "Admin" Spot . init     "gold"
-transact "Admin" Spot . setPrice "gold" 1
+transact ADMIN Spot . init     "gold"
+transact ADMIN Spot . setPrice "gold" 1
 
 // Initialize Pot
-transact "Admin" Pot . file vow-file "VOW"
-transact "Admin" Pot . initUser "Alice"
-transact "Admin" Pot . initUser "Bobby"
+transact ADMIN Pot . file vow-file "VOW"
+transact ADMIN Pot . initUser "Alice"
+transact ADMIN Pot . initUser "Bobby"
 
 // Initialize Vat, both total Line and gold parameters
-transact "Admin" Vat . file Line 1000 ether
-transact "Admin" Vat . initIlk "gold"
-transact "Admin" Vat . file spot "gold" 3 ether
-transact "Admin" Vat . file line "gold" 1000 ether
+transact ADMIN Vat . file Line 1000 ether
+transact ADMIN Vat . initIlk "gold"
+transact ADMIN Vat . file spot "gold" 3 ether
+transact ADMIN Vat . file line "gold" 1000 ether
 
 // Initialize "VOW", "FLAP", "END" addresses for Vat.
-transact "Admin" Vat . initUser "VOW"
-transact "Admin" Vat . initUser "POT"
-transact "Admin" Vat . initUser "FLAP"
-transact "Admin" Vat . initUser "END"
-transact "Admin" Vat . initGem "gold" "END"
+transact ADMIN Vat . initUser "VOW"
+transact ADMIN Vat . initUser "POT"
+transact ADMIN Vat . initUser "FLAP"
+transact ADMIN Vat . initUser "END"
+transact ADMIN Vat . initGem "gold" "END"
 
 // Initialize users Alice and Bob with gold Gem
-transact "Admin" Vat . initUser "Alice"
-transact "Admin" Vat . initGem "gold" "Alice"
-transact "Admin" Vat . initCDP "gold" "Alice"
+transact ADMIN Vat . initUser "Alice"
+transact ADMIN Vat . initGem "gold" "Alice"
+transact ADMIN Vat . initCDP "gold" "Alice"
 transact "Alice" Vat . hope "POT"
 
-transact "Admin" Vat . initUser "Bobby"
-transact "Admin" Vat . initGem "gold" "Bobby"
-transact "Admin" Vat . initCDP "gold" "Bobby"
+transact ADMIN Vat . initUser "Bobby"
+transact ADMIN Vat . initGem "gold" "Bobby"
+transact ADMIN Vat . initCDP "gold" "Bobby"
 transact "Bobby" Vat . hope "POT"
 
 // Setup CDPs
@@ -49,15 +46,15 @@ transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" 10 10
 transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10
 
 // Attack sequence
-transact "Admin" End . cage
-transact "Admin" End . cage "gold"
-transact "Admin" End . initGap "gold"       // injected because no default setting of `gap` to 0
-transact "Admin" End . skim "gold" "Alice"
-transact "Admin" End . skim "gold" "Bobby"
-transact "Admin" End . thaw
-transact "Admin" End . flow "gold"
+transact ADMIN End . cage
+transact ADMIN End . cage "gold"
+transact ADMIN End . initGap "gold"       // injected because no default setting of `gap` to 0
+transact ADMIN End . skim "gold" "Alice"
+transact ADMIN End . skim "gold" "Bobby"
+transact ADMIN End . thaw
+transact ADMIN End . flow "gold"
 transact "Alice" Pot . join 10
-transact "Admin" Pot . file dsr 2
+transact ADMIN Pot . file dsr 2
 TimeStep 1 second
 transact "Alice" Pot . drip
 transact "Alice" Pot . exit 10

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -4,34 +4,34 @@ authorize "Admin"
 // Initialize gold Gem and GemJoin
 transact "Admin" Gem "gold" . init
 transact "Admin" Gem "gold" . initUser "Alice"
-transact "Admin" Gem "gold" . initUser "Bob"
+transact "Admin" Gem "gold" . initUser "Bobby"
 transact "Admin" Gem "gold" . mint "Alice" 10
-transact "Admin" Gem "gold" . mint "Bob"   10
+transact "Admin" Gem "gold" . mint "Bobby" 10
 transact "Admin" GemJoin "gold" . init
 
 // Initialize Vat, both total Line and gold parameters
 transact "Admin" Vat . file Line 1000 ether
 transact "Admin" Vat . initIlk "gold"
-transact "Admin" Vat . file spot "gold" 3    ether
+transact "Admin" Vat . file spot "gold" 3 ether
 transact "Admin" Vat . file line "gold" 1000 ether
 
 // Initialize users Alice and Bob with gold Gem
 transact "Admin" Vat . initUser "Alice"
-transact "Admin" Vat . initUser "Bob"
+transact "Admin" Vat . initUser "Bobby"
 transact "Admin" Vat . initCDP "gold" "Alice"
-transact "Admin" Vat . initCDP "gold" "Bob"
+transact "Admin" Vat . initCDP "gold" "Bobby"
 
 // Setup CDPs
 transact "Alice" GemJoin "gold" . join "Alice" 10
-transact "Bob"   GemJoin "gold" . join "Bob"   10
+transact "Bobby" GemJoin "gold" . join "Bobby" 10
 transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" 10 10
-transact "Bob"   Vat . frob "gold" "Bob"   "Bob"   "Bob"   10 10
+transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10
 
 // Attack sequence
 transact "Admin" End . cage
 transact "Admin" End . cage "gold"
 transact "Admin" End . skim "gold" "Alice"
-transact "Admin" End . skim "gold" "Bob"
+transact "Admin" End . skim "gold" "Bobby"
 transact "Admin" End . thaw
 transact "Admin" End . flow "gold"
 transact "Alice" Pot . drip

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -1,0 +1,386 @@
+<kmcd>
+  <kmcd-driver>
+    <k>
+      .
+    </k>
+    <msg-sender>
+      "Alice"
+    </msg-sender>
+    <this>
+      "Alice"
+    </this>
+    <current-time>
+      1
+    </current-time>
+    <call-stack>
+      .List
+    </call-stack>
+    <pre-state>
+      .
+    </pre-state>
+    <events>
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 10 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 10 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , End . thaw ) )
+      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . drip ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
+    </events>
+    <frame-events>
+      .List
+    </frame-events>
+  </kmcd-driver>
+  <kmcd-state>
+    <cat>
+      <cat-wards>
+        SetItem ( End )
+      </cat-wards>
+      <cat-ilks>
+        .Map
+      </cat-ilks>
+      <cat-live>
+        false
+      </cat-live>
+      <cat-vow>
+        0
+      </cat-vow>
+    </cat>
+    <dai>
+      <dai-wards>
+        .Set
+      </dai-wards>
+      <dai-totalSupply>
+        0
+      </dai-totalSupply>
+      <dai-account-id>
+        0
+      </dai-account-id>
+      <dai-balance>
+        .Map
+      </dai-balance>
+      <dai-allowance>
+        .Map
+      </dai-allowance>
+      <dai-nonce>
+        .Map
+      </dai-nonce>
+    </dai>
+    <end-state>
+      <endPhase>
+        false
+      </endPhase>
+      <end>
+        <end-wards>
+          .Set
+        </end-wards>
+        <end-live>
+          false
+        </end-live>
+        <end-when>
+          0
+        </end-when>
+        <end-wait>
+          0
+        </end-wait>
+        <end-debt>
+          20
+        </end-debt>
+        <end-tag>
+          "gold" |-> 1
+        </end-tag>
+        <end-gap>
+          "gold" |-> 0
+        </end-gap>
+        <end-art>
+          "gold" |-> 20
+        </end-art>
+        <end-fix>
+          "gold" |-> 1
+        </end-fix>
+        <end-bag>
+          .Map
+        </end-bag>
+        <end-out>
+          .Map
+        </end-out>
+      </end>
+    </end-state>
+    <flap-state>
+      <flap-wards>
+        SetItem ( Vow )
+      </flap-wards>
+      <flap-bids>
+        .Map
+      </flap-bids>
+      <flap-kicks>
+        0
+      </flap-kicks>
+      <flap-live>
+        false
+      </flap-live>
+      <flap-beg>
+        21 /Rat 20
+      </flap-beg>
+      <flap-ttl>
+        10800
+      </flap-ttl>
+      <flap-tau>
+        172800
+      </flap-tau>
+    </flap-state>
+    <flips>
+      .FlipCellMap
+    </flips>
+    <flop-state>
+      <flop-wards>
+        SetItem ( Vow )
+      </flop-wards>
+      <flop-bids>
+        .Map
+      </flop-bids>
+      <flop-kicks>
+        0
+      </flop-kicks>
+      <flop-live>
+        false
+      </flop-live>
+      <flop-beg>
+        21 /Rat 20
+      </flop-beg>
+      <flop-pad>
+        3 /Rat 2
+      </flop-pad>
+      <flop-ttl>
+        10800
+      </flop-ttl>
+      <flop-tau>
+        172800
+      </flop-tau>
+    </flop-state>
+    <gems>
+      <gem>
+        <gem-id>
+          "gold"
+        </gem-id>
+        <gem-wards>
+          .Set
+        </gem-wards>
+        <gem-balances>
+          "Alice" |-> 0
+          "Bobby" |-> 0
+          GemJoin "gold" |-> 20
+        </gem-balances>
+      </gem>
+    </gems>
+    <join-state>
+      <gem-joins>
+        .GemJoinCellMap
+      </gem-joins>
+      <dai-join>
+        <dai-join-wards>
+          .Set
+        </dai-join-wards>
+      </dai-join>
+    </join-state>
+    <jug>
+      <jug-wards>
+        .Set
+      </jug-wards>
+      <jug-ilks>
+        .Map
+      </jug-ilks>
+      <jug-vow>
+        0
+      </jug-vow>
+      <jug-base>
+        0
+      </jug-base>
+    </jug>
+    <pot>
+      <pot-wards>
+        SetItem ( End )
+      </pot-wards>
+      <pot-pies>
+        "Alice" |-> 0
+        "Bobby" |-> 0
+      </pot-pies>
+      <pot-pie>
+        0
+      </pot-pie>
+      <pot-dsr>
+        1
+      </pot-dsr>
+      <pot-chi>
+        1
+      </pot-chi>
+      <pot-vow>
+        Vow
+      </pot-vow>
+      <pot-rho>
+        1
+      </pot-rho>
+      <pot-live>
+        false
+      </pot-live>
+    </pot>
+    <spot>
+      <spot-wards>
+        .Set
+      </spot-wards>
+      <spot-ilks>
+        "gold" |-> SpotIlk ( 1 , 1 )
+      </spot-ilks>
+      <spot-par>
+        1
+      </spot-par>
+    </spot>
+    <vat>
+      <vat-wards>
+        SetItem ( End )
+        SetItem ( GemJoin "gold" )
+        SetItem ( Pot )
+      </vat-wards>
+      <vat-can>
+        "Alice" |-> SetItem ( Pot )
+        "Bobby" |-> SetItem ( Pot )
+        End |-> .Set
+        Flap |-> .Set
+        Pot |-> .Set
+        Vow |-> .Set
+      </vat-can>
+      <vat-ilks>
+        "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
+      </vat-ilks>
+      <vat-urns>
+        { "gold" , "Alice" } |-> Urn ( 0 , 0 )
+        { "gold" , "Bobby" } |-> Urn ( 0 , 0 )
+      </vat-urns>
+      <vat-gem>
+        { "gold" , "Alice" } |-> 0
+        { "gold" , "Bobby" } |-> 0
+        { "gold" , End } |-> 20
+      </vat-gem>
+      <vat-dai>
+        "Alice" |-> 10
+        "Bobby" |-> 10
+        End |-> 0
+        Flap |-> 0
+        Pot |-> 0
+        Vow |-> 0
+      </vat-dai>
+      <vat-sin>
+        "Alice" |-> 0
+        "Bobby" |-> 0
+        End |-> 0
+        Flap |-> 0
+        Pot |-> 0
+        Vow |-> 20
+      </vat-sin>
+      <vat-debt>
+        20
+      </vat-debt>
+      <vat-vice>
+        20
+      </vat-vice>
+      <vat-Line>
+        1000000000000
+      </vat-Line>
+      <vat-live>
+        false
+      </vat-live>
+    </vat>
+    <vow>
+      <vow-wards>
+        SetItem ( End )
+      </vow-wards>
+      <vow-sins>
+        .Map
+      </vow-sins>
+      <vow-sin>
+        0
+      </vow-sin>
+      <vow-ash>
+        0
+      </vow-ash>
+      <vow-wait>
+        0
+      </vow-wait>
+      <vow-dump>
+        0
+      </vow-dump>
+      <vow-sump>
+        0
+      </vow-sump>
+      <vow-bump>
+        0
+      </vow-bump>
+      <vow-hump>
+        0
+      </vow-hump>
+      <vow-live>
+        false
+      </vow-live>
+    </vow>
+  </kmcd-state>
+</kmcd>

--- a/vat.md
+++ b/vat.md
@@ -282,16 +282,15 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatStep ::= "move" Address Address Wad
  // ---------------------------------------------
-    rule <k> Vat . move ADDRFROM ADDRTO DAI => .
-         ...
-         </k>
+    rule <k> Vat . move ADDRFROM ADDRTO DAI => . ... </k>
          <vat-dai>
            ...
            ADDRFROM |-> (DAIFROM => DAIFROM -Rat DAI)
            ADDRTO   |-> (DAITO   => DAITO   +Rat DAI)
            ...
          </vat-dai>
-      requires wish ADDRFROM
+      requires DAIFROM >=Rat DAI
+       andBool wish ADDRFROM
 ```
 
 ### CDP Manipulation

--- a/vat.md
+++ b/vat.md
@@ -348,7 +348,7 @@ This is quite permissive, and would allow the account to drain all your locked c
          </vat-gem>
          <vat-sin>
            ...
-           USERW |-> ( SINW => SINW -Rat (RATE *Rat DART) )
+           ADDRW |-> ( SINW => SINW -Rat (RATE *Rat DART) )
            ...
          </vat-sin>
 

--- a/vat.md
+++ b/vat.md
@@ -377,7 +377,7 @@ This is quite permissive, and would allow the account to drain all your locked c
          </vat-gem>
          <vat-dai>
            ...
-           USERW |-> ( DAIW => DAIW +Rat (RATE *Rat DART) )
+           ADDRW |-> ( DAIW => DAIW +Rat (RATE *Rat DART) )
            ...
          </vat-dai>
          <vat-Line> LINE </vat-Line>

--- a/vat.md
+++ b/vat.md
@@ -146,6 +146,43 @@ The parameters controlled by governance are:
          <vat-ilks> ... ILKID |-> Ilk ( ... dust: (_ => DUST) ) ... </vat-ilks>
 ```
 
+Vat Initialization
+------------------
+
+Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
+
+-   `initIlk`: Create a new `VatIlk` which starts with `rate == 1` and all other fields `0`.
+-   `initUser`: Creates `can`, `dai`, and `sin` accounts for a given user in the vat.
+-   `initGem`: Create a new gem of a given ilk for a given address.
+-   `initCDP`: Create an empty CDP of a given ilk for a given user.
+
+```k
+    syntax VatAuthStep ::= "initIlk" String
+                         | "initUser" Address
+                         | "initGem" String Address
+                         | "initCDP" String Address
+ // -----------------------------------------------
+    rule <k> Vat . initIlk ILKID => . ... </k>
+         <vat-ilks> ILKS => ILKS [ ILKID <- Ilk ( ... Art: 0 , rate: 1 , spot: 0 , line: 0 , dust: 0 ) ] </vat-ilks>
+      requires notBool ILKID in_keys(ILKS)
+
+    rule <k> Vat . initUser ADDR => . ... </k>
+         <vat-can> CAN => CAN [ ADDR <- .Set ] </vat-can>
+         <vat-dai> DAI => DAI [ ADDR <- 0    ] </vat-dai>
+         <vat-sin> SIN => SIN [ ADDR <- 0    ] </vat-sin>
+      requires notBool ADDR in_keys(CAN)
+       andBool notBool ADDR in_keys(DAI)
+       andBool notBool ADDR in_keys(SIN)
+
+    rule <k> Vat . initGem ILKID ADDR => . ... </k>
+         <vat-gem> GEMS => GEMS [ { ILKID , ADDR } <- 0 ] </vat-gem>
+      requires notBool { ILKID , ADDR } in_keys(GEMS)
+
+    rule <k> Vat . initCDP ILKID ADDR => . ... </k>
+         <vat-urns> URNS => URNS [ { ILKID , ADDR } <- Urn( ... ink: 0 , art: 0 ) ] </vat-urns>
+      requires notBool { ILKID , ADDR } in_keys(URNS)
+```
+
 Vat Semantics
 -------------
 


### PR DESCRIPTION
Fixes: #84 

-   Several bug-fixes discovered while implementing lucash-pot-end attack.
-   Add state initializers for setting up for attack sequence.
-   Add lucash-pot-end attack and expected output, confirmed locally that without the associated fix the attack goes through.
-   Setup testing harness for KMCD simulations.

Note that in the test expected output, the `Pot . file dsr` step does _not_ show up in the `<events>` output, because that step gets rolled back (because of the extra check against `live`, which is set to `false` by the added `Pot . cage`). Additionally, in `<vat-dai>` we can see that `Alice` and `Bobby` end up with the same amount of dai.