### PR TITLE
Lucash flip end - fixes to semantics and new test case

### DIFF
--- a/end.md
+++ b/end.md
@@ -95,10 +95,20 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
 
 ```k
     syntax EndAuthStep ::= "initGap" String
- // ---------------------------------------
+                         | "initBag" Address
+                         | "initOut" String Address
+ // -----------------------------------------------
     rule <k> End . initGap ILKID => . ... </k>
          <end-gap> GAPS => GAPS [ ILKID <- 0 ] </end-gap>
       requires notBool ILKID in_keys(GAPS)
+
+    rule <k> End . initBag ADDR => . ... </k>
+         <end-bag> BAGS => BAGS [ ADDR <- 0 ] </end-bag>
+      requires notBool ADDR in_keys(BAGS)
+
+    rule <k> End . initOut ILKID ADDR => . ... </k>
+         <end-out> OUTS => OUTS [ { ILKID , ADDR } <- 0 ] </end-out>
+      requires notBool { ILKID , ADDR } in_keys(OUTS)
 ```
 
 End Semantics

--- a/flip.md
+++ b/flip.md
@@ -125,6 +125,18 @@ Flip Events
  // ---------------------------------------------------------------
 ```
 
+Flip Initialization
+-------------------
+
+-   `init` initializes a `<flip>` sub-configuration contract for a given ilk.
+
+```k
+    syntax FlipAuthStep ::= "init"
+ // ------------------------------
+    rule <k> Flip ILK . init => . ... </k>
+         <flips> ... (.Bag => <flip> <flip-ilk> ILK </flip-ilk> ... </flip>) ... </flips>
+```
+
 Flip Semantics
 --------------
 

--- a/flip.md
+++ b/flip.md
@@ -137,31 +137,33 @@ Flip Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <current-time> NOW </current-time>
-         <flip-ilk> ILK </flip-ilk>
-         <flip-tau> TAU </flip-tau>
-         <flip-kicks> KICKS => KICKS +Int 1 </flip-kicks>
-         <flip-bids>... .Map =>
-           KICKS +Int 1 |-> FlipBid(...
-                             bid: BID,
-                             lot: LOT,
-                             guy: MSGSENDER,
-                             tic: 0,
-                             end: NOW +Int TAU,
-                             usr: USR,
-                             gal: GAL,
-                             tab: TAB)
-         ...</flip-bids>
+         <flip>
+           <flip-ilk> ILK </flip-ilk>
+           <flip-tau> TAU </flip-tau>
+           <flip-kicks> KICKS => KICKS +Int 1 </flip-kicks>
+           <flip-bids>
+             ...
+             .Map => KICKS +Int 1 |-> FlipBid( ... bid: BID, lot: LOT, guy: MSGSENDER, tic: 0, end: NOW +Int TAU, usr: USR, gal: GAL, tab: TAB )
+             ...
+           </flip-bids>
+           ...
+         </flip>
          <frame-events> _ => ListItem(FlipKick(KICKS +Int 1, LOT, BID, TAB, USR, GAL)) </frame-events>
 
     syntax FlipStep ::= "tick" Int
  // ------------------------------
     rule <k> Flip ILK . tick ID => . ... </k>
          <current-time> NOW </current-time>
-         <flip-ilk> ILK </flip-ilk>
-         <flip-tau> TAU </flip-tau>
-         <flip-bids>...
-           ID |-> FlipBid(... tic: TIC, end: END => NOW +Int TAU)
-         ...</flip-bids>
+         <flip>
+           <flip-ilk> ILK </flip-ilk>
+           <flip-tau> TAU </flip-tau>
+           <flip-bids>
+             ...
+             ID |-> FlipBid(... tic: TIC, end: END => NOW +Int TAU)
+             ...
+           </flip-bids>
+           ...
+         </flip>
       requires END  <Int NOW
        andBool TIC ==Int 0
 
@@ -172,18 +174,17 @@ Flip Semantics
           ~> call Vat . move MSGSENDER GAL (BID -Rat BID') ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <current-time> NOW </current-time>
-         <flip-ilk> ILK </flip-ilk>
-         <flip-beg> BEG </flip-beg>
-         <flip-ttl> TTL </flip-ttl>
-         <flip-bids>...
-           ID |-> FlipBid(... bid: BID' => BID,
-                              lot: LOT',
-                              guy: GUY => MSGSENDER,
-                              tic: TIC => NOW +Int TTL,
-                              end: END,
-                              gal: GAL,
-                              tab: TAB)
-         ...</flip-bids>
+         <flip>
+           <flip-ilk> ILK </flip-ilk>
+           <flip-beg> BEG </flip-beg>
+           <flip-ttl> TTL </flip-ttl>
+           <flip-bids>
+             ...
+             ID |-> FlipBid(... bid: BID' => BID, lot: LOT', guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, gal: GAL, tab: TAB)
+           ...
+           </flip-bids>
+           ...
+         </flip>
       requires GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
@@ -200,18 +201,17 @@ Flip Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <current-time> NOW </current-time>
-         <flip-ilk> ILK </flip-ilk>
-         <flip-beg> BEG </flip-beg>
-         <flip-ttl> TTL </flip-ttl>
-         <flip-bids>...
-           ID |-> FlipBid(... bid: BID',
-                              lot: LOT' => LOT,
-                              guy: GUY => MSGSENDER,
-                              tic: TIC => NOW +Int TTL,
-                              end: END,
-                              usr: USR,
-                              tab: TAB)
-         ...</flip-bids>
+         <flip>
+           <flip-ilk> ILK </flip-ilk>
+           <flip-beg> BEG </flip-beg>
+           <flip-ttl> TTL </flip-ttl>
+           <flip-bids>
+             ...
+             ID |-> FlipBid(... bid: BID', lot: LOT' => LOT, guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, usr: USR, tab: TAB)
+             ...
+           </flip-bids>
+           ...
+         </flip>
       requires GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
@@ -225,10 +225,15 @@ Flip Semantics
     rule <k> Flip ILK . deal ID => call Vat . flux ILK THIS GUY LOT ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
-         <flip-ilk> ILK </flip-ilk>
-         <flip-bids>...
-           ID |-> FlipBid(... lot: LOT, guy: GUY, tic: TIC, end: END) => .Map
-         ...</flip-bids>
+         <flip>
+           <flip-ilk> ILK </flip-ilk>
+           <flip-bids>
+             ...
+             ID |-> FlipBid(... lot: LOT, guy: GUY, tic: TIC, end: END) => .Map
+             ...
+           </flip-bids>
+           ...
+         </flip>
       requires TIC =/=Int 0
        andBool (TIC <Int NOW orBool END <Int NOW)
 
@@ -239,10 +244,15 @@ Flip Semantics
           ~> call Vat . move MSGSENDER GUY BID ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <flip-ilk> ILK </flip-ilk>
-         <flip-bids>...
-           ID |-> FlipBid(... bid: BID, lot: LOT, guy: GUY, tab: TAB) => .Map
-         ...</flip-bids>
+         <flip>
+           <flip-ilk> ILK </flip-ilk>
+           <flip-bids>
+             ...
+             ID |-> FlipBid(... bid: BID, lot: LOT, guy: GUY, tab: TAB) => .Map
+             ...
+           </flip-bids>
+           ...
+         </flip>
       requires GUY =/=K 0 andBool BID <Rat TAB
 ```
 

--- a/jug.md
+++ b/jug.md
@@ -94,12 +94,11 @@ Jug Semantics
 -------------
 
 ```k
-    syntax JugAuthStep ::= InitStep
- // -------------------------------
+    syntax JugAuthStep ::= "init" String
+ // ------------------------------------
     rule <k> Jug . init ILK => . ... </k>
-         <current-time> TIME </current-time>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY => 1, rho: _ => TIME ) ... </jug-ilks>
-      requires ILKDUTY ==Int 0
+         <current-time> NOW </current-time>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: 0 => 1, rho: _ => NOW ) ... </jug-ilks>
 ```
 
 ```k

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -117,6 +117,10 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
          <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires isAuthStep(MCD) impliesBool isAuthorized(THIS, contract(MCD))
 
+    rule <k> call MCD:AuthStep => exception MCD ... </k>
+         <this> THIS </this>
+      requires notBool isAuthorized(THIS, contract(MCD))
+
     syntax ReturnValue ::= Int | Rat
  // --------------------------------
     rule <k> R:ReturnValue => . ... </k>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -93,6 +93,9 @@ Use `transact ...` for initiating top-level calls from a given user.
     rule <k> transact ADDR:Address MCD:MCDStep => pushState ~> call MCD ~> dropState ... </k>
          <this> _ => ADDR </this>
          <msg-sender> _ => ADDR </msg-sender>
+         <call-stack> _ => .List </call-stack>
+         <pre-state> _ => .K </pre-state>
+         <frame-events> _ => .List </frame-events>
 
     syntax AdminStep ::= "pushState" | "dropState" | "popState"
  // -----------------------------------------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -156,16 +156,6 @@ Most operations add to the log, which stores the address which made the call and
  // ------------------------------------------
 ```
 
-Simulations
------------
-
-Different contracts use the same names for external functions, so we declare them here.
-
-```k
-    syntax InitStep ::= "init" Int
- // ------------------------------
-```
-
 Base Data
 ---------
 

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -94,8 +94,8 @@ Use `transact ...` for initiating top-level calls from a given user.
          <this> _ => ADDR </this>
          <msg-sender> _ => ADDR </msg-sender>
 
-    syntax MCDStep ::= "pushState" | "dropState" | "popState"
- // ---------------------------------------------------------
+    syntax AdminStep ::= "pushState" | "dropState" | "popState"
+ // -----------------------------------------------------------
 ```
 
 Function Calls

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -120,9 +120,7 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
          <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
       requires isAuthStep(MCD) impliesBool isAuthorized(THIS, contract(MCD))
 
-    rule <k> call MCD:AuthStep => exception MCD ... </k>
-         <this> THIS </this>
-      requires notBool isAuthorized(THIS, contract(MCD))
+    rule <k> call MCD => exception MCD ... </k> [owise]
 
     syntax ReturnValue ::= Rat
  // --------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -17,6 +17,7 @@ module KMCD-DRIVER
     configuration
         <kmcd-driver>
           <k> $PGM:MCDSteps </k>
+          <return-value> .K </return-value>
           <msg-sender> 0:Address </msg-sender>
           <this> 0:Address </this>
           <current-time> 0:Int </current-time>
@@ -118,12 +119,8 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     syntax ReturnValue ::= Int | Rat
  // --------------------------------
-    rule <k> R:ReturnValue => R ~> CONT </k>
-         <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
-         <this> THIS => MSGSENDER </this>
-         <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </call-stack>
-         <events> L => L EVENTS </events>
-         <frame-events> EVENTS => PREVEVENTS </frame-events>
+    rule <k> R:ReturnValue => . ... </k>
+         <return-value> _ => R </return-value>
 
     rule <k> . => CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -124,8 +124,8 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
          <this> THIS </this>
       requires notBool isAuthorized(THIS, contract(MCD))
 
-    syntax ReturnValue ::= Int | Rat
- // --------------------------------
+    syntax ReturnValue ::= Rat
+ // --------------------------
     rule <k> R:ReturnValue => . ... </k>
          <return-value> _ => R </return-value>
 

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -96,6 +96,7 @@ Use `transact ...` for initiating top-level calls from a given user.
          <call-stack> _ => .List </call-stack>
          <pre-state> _ => .K </pre-state>
          <frame-events> _ => .List </frame-events>
+         <return-value> _ => .K </return-value>
 
     syntax AdminStep ::= "pushState" | "dropState" | "popState"
  // -----------------------------------------------------------

--- a/kmcd.md
+++ b/kmcd.md
@@ -77,7 +77,7 @@ State Storage/Revert Semantics
 
     rule <k> popState => . ... </k>
          (_:KmcdStateCell => <kmcd-state> STATE </kmcd-state>)
-         <pre-state> <kmcd-state> STATE </kmcd-state> </pre-state>
+         <pre-state> <kmcd-state> STATE </kmcd-state> => .K </pre-state>
 ```
 
 ```k

--- a/tests/attacks/lucash-flip-end.mcd
+++ b/tests/attacks/lucash-flip-end.mcd
@@ -1,0 +1,112 @@
+// MCD Internal Contract Setup
+// ---------------------------
+
+// Auhthorize Pot/End for Vat
+transact ADMIN Vat . rely Pot
+transact ADMIN Vat . rely End
+
+// Authorize End for Cat/Vow/Pot
+transact ADMIN Cat . rely End
+transact ADMIN Vow . rely End
+transact ADMIN Pot . rely End
+
+// Authorize Vow for Flap/Flop
+transact ADMIN Flap . rely Vow
+transact ADMIN Flop . rely Vow
+
+// Initialize Vat accounts for Vow/Pot/Flap/End
+transact ADMIN Vat . initUser Vow
+transact ADMIN Vat . initUser Pot
+transact ADMIN Vat . initUser Flap
+transact ADMIN Vat . initUser End
+
+// File Vow contract for Pot (since Pot doesn't depend on Vow?)
+transact ADMIN Pot . file vow-file Vow
+
+// Collateral Setup
+// ----------------
+
+// "gold" collateral and joiner
+transact ADMIN Gem "gold" . init
+transact ADMIN GemJoin "gold" . init
+
+// Allow GemJoin "gold" to call into Vat
+transact ADMIN Vat . rely GemJoin "gold"
+transact ADMIN Vat . initGem "gold" End
+
+// Initialize Spot for gold
+transact ADMIN Spot . init     "gold"
+transact ADMIN Spot . setPrice "gold" 1
+
+// Initialize Flipper for gold
+transact ADMIN Flip "gold" . init
+transact ADMIN Flip "gold" . rely End
+
+// Initialize Vat, both total Line and gold parameters
+transact ADMIN Vat . file Line 1000 ether
+transact ADMIN Vat . initIlk "gold"
+transact ADMIN Vat . file spot "gold" 3 ether
+transact ADMIN Vat . file line "gold" 1000 ether
+
+// Initialize Vat accounts for (Flip "gold") and End
+transact ADMIN Vat . initGem "gold" Flip "gold"
+transact ADMIN Vat . initCDP "gold" End
+
+// Initialize End parameters to 0
+transact ADMIN End . initGap "gold"
+transact ADMIN End . initBag "Bobby"
+transact ADMIN End . initOut "gold" "Bobby"
+
+// User Setup
+// ----------
+
+// Initialize gold Gem and GemJoin
+transact ADMIN Gem "gold" . initUser "Alice"
+transact ADMIN Gem "gold" . initUser "Bobby"
+transact ADMIN Gem "gold" . mint "Alice" 20
+transact ADMIN Gem "gold" . mint "Bobby" 20
+
+// Initialize Pot
+transact ADMIN Pot . initUser "Alice"
+transact ADMIN Pot . initUser "Bobby"
+
+// Initialize users Alice and Bob with gold Gem
+transact ADMIN Vat . initUser "Alice"
+transact ADMIN Vat . initGem "gold" "Alice"
+transact ADMIN Vat . initCDP "gold" "Alice"
+transact "Alice" Vat . hope Pot
+
+transact ADMIN Vat . initUser "Bobby"
+transact ADMIN Vat . initGem "gold" "Bobby"
+transact ADMIN Vat . initCDP "gold" "Bobby"
+transact "Bobby" Vat . hope Pot
+transact "Bobby" Vat . hope Flip "gold"
+transact "Bobby" Vat . hope End
+
+// Setup CDPs
+transact "Alice" GemJoin "gold" . join "Alice" 10
+transact "Bobby" GemJoin "gold" . join "Bobby" 10
+transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" 10 10
+transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10
+
+// Attack Sequence
+// ---------------
+
+transact "Bobby" GemJoin "gold" . join "Bobby" 1
+transact ADMIN End . cage
+transact ADMIN End . cage "gold"
+TimeStep 1 hour
+transact ADMIN End . thaw
+transact ADMIN End . flow "gold"
+
+//transact "Bobby" End . skip "gold" (call "Bobby" Flip "gold" . kick End "Bobby" 1001 ether 1 1000 ether)
+transact "Bobby" Flip "gold" . kick End "Bobby" 1001 ether 1 1000 ether
+transact "Bobby" End . skip "gold" 1
+
+// transact "Bobby" End . pack (call "Bobby" Vat . dai)
+transact "Bobby" End . pack 1000000000010
+
+//transact "Bobby" End . cash "gold" (call "Bobby" End . bag)
+transact "Bobby" End . cash "gold" 1000000000010
+
+.MCDSteps

--- a/tests/attacks/lucash-flip-end.mcd
+++ b/tests/attacks/lucash-flip-end.mcd
@@ -99,6 +99,7 @@ TimeStep 1 hour
 transact ADMIN End . thaw
 transact ADMIN End . flow "gold"
 
+// Every call after this reverts in fixed version
 //transact "Bobby" End . skip "gold" (call "Bobby" Flip "gold" . kick End "Bobby" 1001 ether 1 1000 ether)
 transact "Bobby" Flip "gold" . kick End "Bobby" 1001 ether 1 1000 ether
 transact "Bobby" End . skip "gold" 1

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -4,7 +4,7 @@
       .
     </k>
     <return-value>
-      1
+      .
     </return-value>
     <msg-sender>
       "Bobby"
@@ -90,20 +90,6 @@
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-      ListItem ( LogNote ( "Bobby" , Vat . flux "gold" "Bobby" Flip "gold" 1 ) )
-      ListItem ( FlipKick ( 1 , 1 , 1000000000000 , 1001000000000 , End , "Bobby" ) )
-      ListItem ( LogNote ( "Bobby" , Vat . suck Vow Vow 1001000000000 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . suck Vow End 1000000000000 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( LogNote ( End , Vat . flux "gold" Flip "gold" End 1 ) )
-      ListItem ( LogNote ( End , Vat . move End "Bobby" 1000000000000 ) )
-      ListItem ( LogNote ( "Bobby" , Flip "gold" . yank 1 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . grab "gold" End End Vow 1 1001000000000 ) )
-      ListItem ( LogNote ( "Bobby" , End . skip "gold" 1 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Vow 1000000000010 ) )
-      ListItem ( LogNote ( "Bobby" , End . pack 1000000000010 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . flux "gold" End "Bobby" 1000000000010 ) )
-      ListItem ( LogNote ( "Bobby" , End . cash "gold" 1000000000010 ) )
     </events>
     <frame-events>
       .List
@@ -171,16 +157,16 @@
           "gold" |-> 0
         </end-gap>
         <end-art>
-          "gold" |-> 1001000000020
+          "gold" |-> 20
         </end-art>
         <end-fix>
           "gold" |-> 1
         </end-fix>
         <end-bag>
-          "Bobby" |-> 1000000000010
+          "Bobby" |-> 0
         </end-bag>
         <end-out>
-          { "gold" , "Bobby" } |-> 1000000000010
+          { "gold" , "Bobby" } |-> 0
         </end-out>
       </end>
     </end-state>
@@ -228,7 +214,7 @@
           172800
         </flip-tau>
         <flip-kicks>
-          1
+          0
         </flip-kicks>
       </flip>
     </flips>
@@ -346,32 +332,32 @@
         "Bobby" |-> SetItem ( End )
         SetItem ( Flip "gold" )
         SetItem ( Pot )
-        End |-> SetItem ( Flip "gold" )
+        End |-> .Set
         Flap |-> .Set
         Pot |-> .Set
         Vow |-> .Set
       </vat-can>
       <vat-ilks>
-        "gold" |-> Ilk ( 1001000000020 , 1 , 3000000000 , 1000000000000 , 0 )
+        "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
       </vat-ilks>
       <vat-urns>
         { "gold" , "Alice" } |-> Urn ( 10 , 10 )
         { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-        { "gold" , End } |-> Urn ( 1 , 1001000000000 )
+        { "gold" , End } |-> Urn ( 0 , 0 )
       </vat-urns>
       <vat-gem>
         { "gold" , "Alice" } |-> 0
-        { "gold" , "Bobby" } |-> 1000000000010
-        { "gold" , End } |-> -1000000000010
+        { "gold" , "Bobby" } |-> 1
+        { "gold" , End } |-> 0
         { "gold" , Flip "gold" } |-> 0
       </vat-gem>
       <vat-dai>
         "Alice" |-> 10
-        "Bobby" |-> 0
+        "Bobby" |-> 10
         End |-> 0
         Flap |-> 0
         Pot |-> 0
-        Vow |-> 2001000000010
+        Vow |-> 0
       </vat-dai>
       <vat-sin>
         "Alice" |-> 0
@@ -379,13 +365,13 @@
         End |-> 0
         Flap |-> 0
         Pot |-> 0
-        Vow |-> 1000000000000
+        Vow |-> 0
       </vat-sin>
       <vat-debt>
-        2001000000020
+        20
       </vat-debt>
       <vat-vice>
-        1000000000000
+        0
       </vat-vice>
       <vat-Line>
         1000000000000

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -1,0 +1,430 @@
+<kmcd>
+  <kmcd-driver>
+    <k>
+      .
+    </k>
+    <return-value>
+      1
+    </return-value>
+    <msg-sender>
+      "Bobby"
+    </msg-sender>
+    <this>
+      "Bobby"
+    </this>
+    <current-time>
+      3600
+    </current-time>
+    <call-stack>
+      .List
+    </call-stack>
+    <pre-state>
+      .
+    </pre-state>
+    <events>
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( LogNote ( ADMIN , End . thaw ) )
+      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+      ListItem ( LogNote ( "Bobby" , Vat . flux "gold" "Bobby" Flip "gold" 1 ) )
+      ListItem ( FlipKick ( 1 , 1 , 1000000000000 , 1001000000000 , End , "Bobby" ) )
+      ListItem ( LogNote ( "Bobby" , Vat . suck Vow Vow 1001000000000 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . suck Vow End 1000000000000 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( LogNote ( End , Vat . flux "gold" Flip "gold" End 1 ) )
+      ListItem ( LogNote ( End , Vat . move End "Bobby" 1000000000000 ) )
+      ListItem ( LogNote ( "Bobby" , Flip "gold" . yank 1 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . grab "gold" End End Vow 1 1001000000000 ) )
+      ListItem ( LogNote ( "Bobby" , End . skip "gold" 1 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Vow 1000000000010 ) )
+      ListItem ( LogNote ( "Bobby" , End . pack 1000000000010 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . flux "gold" End "Bobby" 1000000000010 ) )
+      ListItem ( LogNote ( "Bobby" , End . cash "gold" 1000000000010 ) )
+    </events>
+    <frame-events>
+      .List
+    </frame-events>
+  </kmcd-driver>
+  <kmcd-state>
+    <cat>
+      <cat-wards>
+        SetItem ( End )
+      </cat-wards>
+      <cat-ilks>
+        .Map
+      </cat-ilks>
+      <cat-live>
+        false
+      </cat-live>
+      <cat-vow>
+        0
+      </cat-vow>
+    </cat>
+    <dai>
+      <dai-wards>
+        .Set
+      </dai-wards>
+      <dai-totalSupply>
+        0
+      </dai-totalSupply>
+      <dai-account-id>
+        0
+      </dai-account-id>
+      <dai-balance>
+        .Map
+      </dai-balance>
+      <dai-allowance>
+        .Map
+      </dai-allowance>
+      <dai-nonce>
+        .Map
+      </dai-nonce>
+    </dai>
+    <end-state>
+      <endPhase>
+        false
+      </endPhase>
+      <end>
+        <end-wards>
+          .Set
+        </end-wards>
+        <end-live>
+          false
+        </end-live>
+        <end-when>
+          0
+        </end-when>
+        <end-wait>
+          0
+        </end-wait>
+        <end-debt>
+          20
+        </end-debt>
+        <end-tag>
+          "gold" |-> 1
+        </end-tag>
+        <end-gap>
+          "gold" |-> 0
+        </end-gap>
+        <end-art>
+          "gold" |-> 1001000000020
+        </end-art>
+        <end-fix>
+          "gold" |-> 1
+        </end-fix>
+        <end-bag>
+          "Bobby" |-> 1000000000010
+        </end-bag>
+        <end-out>
+          { "gold" , "Bobby" } |-> 1000000000010
+        </end-out>
+      </end>
+    </end-state>
+    <flap-state>
+      <flap-wards>
+        SetItem ( Vow )
+      </flap-wards>
+      <flap-bids>
+        .Map
+      </flap-bids>
+      <flap-kicks>
+        0
+      </flap-kicks>
+      <flap-live>
+        false
+      </flap-live>
+      <flap-beg>
+        21 /Rat 20
+      </flap-beg>
+      <flap-ttl>
+        10800
+      </flap-ttl>
+      <flap-tau>
+        172800
+      </flap-tau>
+    </flap-state>
+    <flips>
+      <flip>
+        <flip-ilk>
+          "gold"
+        </flip-ilk>
+        <flip-wards>
+          SetItem ( End )
+        </flip-wards>
+        <flip-bids>
+          .Map
+        </flip-bids>
+        <flip-beg>
+          21 /Rat 20
+        </flip-beg>
+        <flip-ttl>
+          10800
+        </flip-ttl>
+        <flip-tau>
+          172800
+        </flip-tau>
+        <flip-kicks>
+          1
+        </flip-kicks>
+      </flip>
+    </flips>
+    <flop-state>
+      <flop-wards>
+        SetItem ( Vow )
+      </flop-wards>
+      <flop-bids>
+        .Map
+      </flop-bids>
+      <flop-kicks>
+        0
+      </flop-kicks>
+      <flop-live>
+        false
+      </flop-live>
+      <flop-beg>
+        21 /Rat 20
+      </flop-beg>
+      <flop-pad>
+        3 /Rat 2
+      </flop-pad>
+      <flop-ttl>
+        10800
+      </flop-ttl>
+      <flop-tau>
+        172800
+      </flop-tau>
+    </flop-state>
+    <gems>
+      <gem>
+        <gem-id>
+          "gold"
+        </gem-id>
+        <gem-wards>
+          .Set
+        </gem-wards>
+        <gem-balances>
+          "Alice" |-> 10
+          "Bobby" |-> 9
+          GemJoin "gold" |-> 21
+        </gem-balances>
+      </gem>
+    </gems>
+    <join-state>
+      <gem-joins>
+        .GemJoinCellMap
+      </gem-joins>
+      <dai-join>
+        <dai-join-wards>
+          .Set
+        </dai-join-wards>
+      </dai-join>
+    </join-state>
+    <jug>
+      <jug-wards>
+        .Set
+      </jug-wards>
+      <jug-ilks>
+        .Map
+      </jug-ilks>
+      <jug-vow>
+        0
+      </jug-vow>
+      <jug-base>
+        0
+      </jug-base>
+    </jug>
+    <pot>
+      <pot-wards>
+        SetItem ( End )
+      </pot-wards>
+      <pot-pies>
+        "Alice" |-> 0
+        "Bobby" |-> 0
+      </pot-pies>
+      <pot-pie>
+        0
+      </pot-pie>
+      <pot-dsr>
+        1
+      </pot-dsr>
+      <pot-chi>
+        1
+      </pot-chi>
+      <pot-vow>
+        Vow
+      </pot-vow>
+      <pot-rho>
+        0
+      </pot-rho>
+      <pot-live>
+        false
+      </pot-live>
+    </pot>
+    <spot>
+      <spot-wards>
+        .Set
+      </spot-wards>
+      <spot-ilks>
+        "gold" |-> SpotIlk ( 1 , 1 )
+      </spot-ilks>
+      <spot-par>
+        1
+      </spot-par>
+    </spot>
+    <vat>
+      <vat-wards>
+        SetItem ( End )
+        SetItem ( GemJoin "gold" )
+        SetItem ( Pot )
+      </vat-wards>
+      <vat-can>
+        "Alice" |-> SetItem ( Pot )
+        "Bobby" |-> SetItem ( End )
+        SetItem ( Flip "gold" )
+        SetItem ( Pot )
+        End |-> SetItem ( Flip "gold" )
+        Flap |-> .Set
+        Pot |-> .Set
+        Vow |-> .Set
+      </vat-can>
+      <vat-ilks>
+        "gold" |-> Ilk ( 1001000000020 , 1 , 3000000000 , 1000000000000 , 0 )
+      </vat-ilks>
+      <vat-urns>
+        { "gold" , "Alice" } |-> Urn ( 10 , 10 )
+        { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
+        { "gold" , End } |-> Urn ( 1 , 1001000000000 )
+      </vat-urns>
+      <vat-gem>
+        { "gold" , "Alice" } |-> 0
+        { "gold" , "Bobby" } |-> 1000000000010
+        { "gold" , End } |-> -1000000000010
+        { "gold" , Flip "gold" } |-> 0
+      </vat-gem>
+      <vat-dai>
+        "Alice" |-> 10
+        "Bobby" |-> 0
+        End |-> 0
+        Flap |-> 0
+        Pot |-> 0
+        Vow |-> 2001000000010
+      </vat-dai>
+      <vat-sin>
+        "Alice" |-> 0
+        "Bobby" |-> 0
+        End |-> 0
+        Flap |-> 0
+        Pot |-> 0
+        Vow |-> 1000000000000
+      </vat-sin>
+      <vat-debt>
+        2001000000020
+      </vat-debt>
+      <vat-vice>
+        1000000000000
+      </vat-vice>
+      <vat-Line>
+        1000000000000
+      </vat-Line>
+      <vat-live>
+        false
+      </vat-live>
+    </vat>
+    <vow>
+      <vow-wards>
+        SetItem ( End )
+      </vow-wards>
+      <vow-sins>
+        .Map
+      </vow-sins>
+      <vow-sin>
+        0
+      </vow-sin>
+      <vow-ash>
+        0
+      </vow-ash>
+      <vow-wait>
+        0
+      </vow-wait>
+      <vow-dump>
+        0
+      </vow-dump>
+      <vow-sump>
+        0
+      </vow-sump>
+      <vow-bump>
+        0
+      </vow-bump>
+      <vow-hump>
+        0
+      </vow-hump>
+      <vow-live>
+        false
+      </vow-live>
+    </vow>
+  </kmcd-state>
+</kmcd>

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -3,6 +3,9 @@
     <k>
       .
     </k>
+    <return-value>
+      .
+    </return-value>
     <msg-sender>
       "Alice"
     </msg-sender>

--- a/vat.md
+++ b/vat.md
@@ -271,11 +271,14 @@ This is quite permissive, and would allow the account to drain all your locked c
 **TODO**: Should be `note`.
 
 ```k
-    syntax VatAuthStep ::= InitStep
- // -------------------------------
+    syntax VatAuthStep ::= "init" String
+ // ------------------------------------
     rule <k> Vat . init ILKID => . ... </k>
-         <vat-ilks> ILKS => ILKS [ ILKID <- 1 ] </vat-ilks>
-      requires notBool ILKID in_keys(ILKS)
+         <vat-ilks>
+           ...
+           ILKID |-> Ilk(... rate: 0 => 1)
+           ...
+         </vat-ilks>
 ```
 
 ### Collateral manipulation (`<vat-gem>`)


### PR DESCRIPTION
-   Test case: `tests/attacks/lucash-flip-end`
-   Updates to how `call`/`transact` harness work.
-   Formatting fixes to `flip.md`.
-   Remove useless `InitStep` sort.
-   Fixes to some `init` methods.