### PR TITLE
Time step log

### DIFF
--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -190,6 +190,9 @@ Some methods rely on a timestamp.
 We simulate that here.
 
 ```k
+    syntax Event ::= TimeStep ( Int )
+ // ---------------------------------
+
     syntax MCDStep ::= "TimeStep"
                      | "TimeStep" Int
  // ---------------------------------
@@ -197,6 +200,7 @@ We simulate that here.
 
     rule <k> TimeStep N => . ... </k>
          <current-time> TIME => TIME +Int N </current-time>
+         <events> ... (.List => ListItem(TimeStep(N))) </events>
       requires N >Int 0
 
     syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -190,8 +190,8 @@ Some methods rely on a timestamp.
 We simulate that here.
 
 ```k
-    syntax Event ::= TimeStep ( Int )
- // ---------------------------------
+    syntax Event ::= TimeStep ( Int , Int )
+ // ---------------------------------------
 
     syntax MCDStep ::= "TimeStep"
                      | "TimeStep" Int
@@ -200,7 +200,7 @@ We simulate that here.
 
     rule <k> TimeStep N => . ... </k>
          <current-time> TIME => TIME +Int N </current-time>
-         <events> ... (.List => ListItem(TimeStep(N))) </events>
+         <events> ... (.List => ListItem(TimeStep(N, TIME +Int N))) </events>
       requires N >Int 0
 
     syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -88,7 +88,7 @@
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-      ListItem ( TimeStep 3600 )
+      ListItem ( TimeStep ( 3600 , 3600 ) )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
     </events>

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -88,6 +88,7 @@
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( TimeStep 3600 )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
     </events>

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -85,6 +85,7 @@
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
       ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
       ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
+      ListItem ( TimeStep 1 )
       ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
       ListItem ( LogNote ( "Alice" , Pot . drip ) )
       ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -85,7 +85,7 @@
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
       ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
       ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
-      ListItem ( TimeStep 1 )
+      ListItem ( TimeStep ( 1 , 1 ) )
       ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
       ListItem ( LogNote ( "Alice" , Pot . drip ) )
       ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -49,6 +49,7 @@
       ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
       ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
+      ListItem ( TimeStep ( 1 , 1 ) )
       ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
       ListItem ( LogNote ( "Alice" , Pot . drip ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" -10 -10 ) )


### PR DESCRIPTION
This PR logs `TimeStep` events and includes the `<current-time>` in the log, which facilitates reading the `<events>` cell at the end of an execution.