### PR TITLE
update flop spec and tests to account for yank-suck changes

### DIFF
--- a/flop.md
+++ b/flop.md
@@ -23,6 +23,7 @@ Flop Configuration
         <flop-pad>    150 /Rat 100 </flop-pad>
         <flop-ttl>    3 hours      </flop-ttl>
         <flop-tau>    2 days       </flop-tau>
+        <flop-vow>    0:Address    </flop-vow>
       </flop-state>
 ```
 
@@ -86,6 +87,7 @@ The parameters controlled by governance are:
                       | "ttl" Int
                       | "tau" Int
                       | "pad" Ray
+                      | "vow-file" Address
  // -----------------------------
     rule <k> Flop . file beg BEG => . ... </k>
          <flop-beg> _ => BEG </flop-beg>
@@ -98,6 +100,9 @@ The parameters controlled by governance are:
 
     rule <k> Flop . file pad PAD => . ... </k>
          <flop-pad> _ => PAD </flop-pad>
+
+    rule <k> Flop . file vow-file ADDR => . ... </k>
+         <flop-vow> _ => ADDR </flop-vow>
 ```
 
 Flop Events
@@ -202,12 +207,13 @@ Flop Semantics
     syntax FlopStep ::= "yank" Int [klabel(FlopYank),symbol]
  // --------------------------------------------------------
     rule <k> Flop . yank ID
-          => call Vat . move THIS GUY BID
+          => call Vat . suck VOWADDR GUY BID
          ...
          </k>
          <this> THIS </this>
          <flop-bids> ... ID |-> FlopBid(... bid: BID, guy: GUY) => .Map ... </flop-bids>
          <flop-live> false </flop-live>
+         <flop-vow> VOWADDR </flop-vow>
 ```
 
 ```k

--- a/flop.md
+++ b/flop.md
@@ -88,7 +88,7 @@ The parameters controlled by governance are:
                       | "tau" Int
                       | "pad" Ray
                       | "vow-file" Address
- // -----------------------------
+ // --------------------------------------
     rule <k> Flop . file beg BEG => . ... </k>
          <flop-beg> _ => BEG </flop-beg>
 

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -261,6 +261,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -266,6 +266,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -263,6 +263,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -270,6 +270,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -269,6 +269,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -280,6 +280,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -251,6 +251,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -257,6 +257,9 @@
           <flop-tau>
             172800
           </flop-tau>
+          <flop-vow>
+            0
+          </flop-vow>
         </flop-state>
         <gems>
           <gem>


### PR DESCRIPTION
Everett and Musab,

I couldn't find where we had updated the Flop spec to account for the bug fix we did, so I took a shot and making the update myself.  I was able to run:
`make deps` (no changes)
`make build -j12` (got though some missing pieces and then didn't fail)
`make test-execution -j12` (identified missing state, then said no changes from `expected`)

Please let me know if there are other things I should run to ensure this is correct and how I could make any improvements to the changes